### PR TITLE
v3.3.2 Hotifx for RealTraffic "Invalid"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 project(LiveTraffic
-        VERSION 3.3.1
+        VERSION 3.3.2
         DESCRIPTION "LiveTraffic X-Plane plugin")
 
 # Provide compile macros from the above project version definition

--- a/Include/LTRealTraffic.h
+++ b/Include/LTRealTraffic.h
@@ -39,7 +39,7 @@
 
 #define REALTRAFFIC_NAME        "RealTraffic"
 #define RT_LOCALHOST            "0.0.0.0"
-constexpr size_t RT_NET_BUF_SIZE    = 512;
+constexpr size_t RT_NET_BUF_SIZE    = 8192;
 
 constexpr double RT_SMOOTH_AIRBORNE = 65.0; // smooth 65s of airborne data
 constexpr double RT_SMOOTH_GROUND   = 35.0; // smooth 35s of ground data
@@ -198,6 +198,7 @@ protected:
     std::map<unsigned long,RTUDPDatagramTy> mapDatagrams;
     // weather, esp. current barometric pressure to correct altitude values
     std::string lastWeather;            // for duplicate detection
+    bool bWeatherErrHappened = false;   ///< Flag: Report UDP errors for weather just once
     /// rolling list of timestamp (diff to now) for detecting historic sending
     std::deque<double> dequeTS;
     /// current timestamp adjustment

--- a/Src/LTRealTraffic.cpp
+++ b/Src/LTRealTraffic.cpp
@@ -524,6 +524,7 @@ void RealTrafficConnection::udpListen ()
     try {
         // Open the UDP port
         bStopUdp = false;
+        bWeatherErrHappened = false;
         udpTrafficData.Open (RT_LOCALHOST,
                              port = DataRefs::GetCfgInt(DR_CFG_RT_TRAFFIC_PORT),
                              RT_NET_BUF_SIZE);
@@ -593,8 +594,14 @@ void RealTrafficConnection::udpListen ()
                     // have it processed
                     ProcessRecvedWeatherData(udpWeatherData.getBuf());
                 }
-                else
-                    retval = -1;
+                else {
+                    // Weather data isn't critical, so we silently swallow it
+                    retval = 0;
+                    if (!bWeatherErrHappened) {
+                        LOG_MSG(logERR, "RealTraffic: Error while trying to receive weather data (reported this once only)");
+                        bWeatherErrHappened = true;
+                    }
+                }
             }
             
             // short-cut if we are to shut down

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -128,6 +128,27 @@
 
     <h2>v3</h2>
 
+    <h3>v3.3.2</h3>
+
+    <P>
+        <b>Update:</b> In case of doubt you can always just copy all files from the archive
+        over the files of your existing installation.
+    </P>
+
+    <P>At least copy the following files, which have changed compared to v3.2.x:</P>
+    <ul>
+        <li><code>lin|mac|win_x64/LiveTraffic.xpl</code></li>
+    </ul>
+
+    <P>Change log:</P>
+
+    <ul>
+        <li>
+            Hotifx for RealTraffic channel turning "invalid": Larger receive buffer and
+            ignore errors on the weather data as weather isn't critical
+        </li>
+    </ul>
+
     <h3>v3.3.1</h3>
 
     <P>
@@ -143,9 +164,11 @@
     <P>Change log:</P>
 
     <ul>
-        <li>RealTraffic: Sending simulator time to RealTraffic app,
+        <li>
+            RealTraffic: Sending simulator time to RealTraffic app,
             so that RealTraffic can send matching historic traffic
-            (activate "Simulator controls time offset" in RealTraffic Advanced Settings).</li>
+            (activate "Simulator controls time offset" in RealTraffic Advanced Settings).
+        </li>
         <li>Fixed default for RealTraffic port (49005) on new installations.</li>
         <li>
             Fixed <a href="https://github.com/TwinFan/XPMP2/issues/54">XPMP2 #54</a>


### PR DESCRIPTION
- Hotifx for RealTraffic channel turning "invalid": Larger receive buffer and ignore errors on the weather data as weather isn't critical