### PR TITLE
v3.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 project(LiveTraffic
-        VERSION 3.4.1
+        VERSION 3.4.2
         DESCRIPTION "LiveTraffic X-Plane plugin")
 
 # Provide compile macros from the above project version definition

--- a/Include/DataRefs.h
+++ b/Include/DataRefs.h
@@ -54,8 +54,8 @@ const bool DEF_SND_FMOD_INST    = false;        ///< Enforce using our own FMOD 
 const bool DEF_SND_FMOD_INST    = true;         ///< Enforce using our own FMOD instance instead of X-Plane's?
 #endif
 const int DEF_SUI_TRANSP        = 0;            ///< Settings UI: transaprent background?
-const int MIN_NETW_TIMEOUT      =  5;           ///< [s] minimum network request timeout
-const int DEF_NETW_TIMEOUT      = 90;           ///< [s] of network request timeout
+const int DEF_MIN_NETW_TIMEOUT  = 5;            ///< [s] default minimum network request timeout
+const int DEF_MAX_NETW_TIMEOUT  = 5;            ///< [s] default maximum network request timeout
 
 
 constexpr int DEF_UI_FONT_SCALE = 100;  ///< [%] Default font scaling
@@ -382,7 +382,8 @@ enum dataRefsLT {
     DR_CFG_FD_LONG_REFRESH_INTVL,
     DR_CFG_FD_BUF_PERIOD,
     DR_CFG_FD_REDUCE_HEIGHT,
-    DR_CFG_NETW_TIMEOUT,
+    DR_CFG_MIN_NETW_TIMEOUT,
+    DR_CFG_MAX_NETW_TIMEOUT,
     DR_CFG_LND_LIGHTS_TAXI,
     DR_CFG_HIDE_BELOW_AGL,
     DR_CFG_HIDE_TAXIING,
@@ -685,7 +686,8 @@ protected:
     int fdCurrRefrIntvl = DEF_FD_REFRESH_INTVL;     ///< current value of how often to fetch new flight data
     int fdBufPeriod     = DEF_FD_BUF_PERIOD;        ///< seconds to buffer before simulating aircraft
     int fdReduceHeight  = DEF_FD_REDUCE_HEIGHT;     ///< [ft] reduce flight data usage when user aircraft is flying above this altitude
-    int netwTimeout     = DEF_NETW_TIMEOUT;         ///< [s] of network request timeout
+    int netwTimeoutMin  = DEF_MIN_NETW_TIMEOUT;     ///< [s] of min network request timeout
+    int netwTimeoutMax  = DEF_MAX_NETW_TIMEOUT;     ///< [s] of max network request timeout
     int bLndLightsTaxi = false;         // keep landing lights on while taxiing? (to be able to see the a/c as there is no taxi light functionality)
     int hideBelowAGL    = 0;            // if positive: a/c visible only above this height AGL
     int hideTaxiing     = 0;            // hide a/c while taxiing?
@@ -922,7 +924,8 @@ public:
     inline int GetFdRefreshIntvl() const { return fdCurrRefrIntvl; }
     inline int GetFdBufPeriod() const { return fdBufPeriod; }
     inline int GetAcOutdatedIntvl() const { return 2 * GetFdBufPeriod(); }
-    inline int GetNetwTimeout() const { return netwTimeout; }
+    inline int GetNetwTimeoutMin() const { return netwTimeoutMin; }
+    inline int GetNetwTimeoutMax() const { return netwTimeoutMax; }
     inline bool GetLndLightsTaxi() const { return bLndLightsTaxi != 0; }
     inline int GetHideBelowAGL() const { return hideBelowAGL; }
     inline bool GetHideTaxiing() const { return hideTaxiing != 0; }

--- a/Include/LTWeather.h
+++ b/Include/LTWeather.h
@@ -1,8 +1,8 @@
 /// @file       LTWeather.h
 /// @brief      Fetch real weather information from AWC
-/// @see        https://www.aviationweather.gov/dataserver/example?datatype=metar
+/// @see        https://aviationweather.gov/data/api/#/Dataserver/dataserverMetars
 /// @author     Birger Hoppe
-/// @copyright  (c) 2018-2020 Birger Hoppe
+/// @copyright  (c) 2018-2023 Birger Hoppe
 /// @copyright  Permission is hereby granted, free of charge, to any person obtaining a
 ///             copy of this software and associated documentation files (the "Software"),
 ///             to deal in the Software without restriction, including without limitation

--- a/LiveTraffic.xcodeproj/project.pbxproj
+++ b/LiveTraffic.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 				KnownAssetTags = (
 					New,
 				);
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 1420;
 			};
 			buildConfigurationList = D607B16209A5563100699BC3 /* Build configuration list for PBXProject "LiveTraffic" */;
 			compatibilityVersion = "Xcode 12.0";
@@ -790,7 +790,7 @@
 				LIVETRAFFIC_VERSION_BETA = 0;
 				LIVETRAFFIC_VER_MAJOR = 3;
 				LIVETRAFFIC_VER_MINOR = 4;
-				LIVETRAFFIC_VER_PATCH = 1;
+				LIVETRAFFIC_VER_PATCH = 2;
 				LLVM_LTO = NO;
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
@@ -896,7 +896,7 @@
 				LIVETRAFFIC_VERSION_BETA = 0;
 				LIVETRAFFIC_VER_MAJOR = 3;
 				LIVETRAFFIC_VER_MINOR = 4;
-				LIVETRAFFIC_VER_PATCH = 1;
+				LIVETRAFFIC_VER_PATCH = 2;
 				LLVM_LTO = YES;
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;

--- a/LiveTraffic.xcodeproj/xcuserdata/birger.xcuserdatad/xcschemes/LiveTraffic.xcscheme
+++ b/LiveTraffic.xcodeproj/xcuserdata/birger.xcuserdatad/xcschemes/LiveTraffic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -2010,7 +2010,7 @@ bool DataRefs::LoadConfigFile()
 
     // which conversion to do with the (older) version of the config file?
     unsigned long cfgFileVer = 0;
-    enum cfgFileConvE { CFG_NO_CONV=0, CFG_V3, CFG_V31, CFG_V331 } conv = CFG_NO_CONV;
+    enum cfgFileConvE { CFG_NO_CONV=0, CFG_V3, CFG_V31, CFG_V331, CFG_V342 } conv = CFG_NO_CONV;
     
     // open a config file
     std::string sFileName (LTCalcFullPath(PATH_CONFIG_FILE));
@@ -2072,8 +2072,10 @@ bool DataRefs::LoadConfigFile()
             // any conversions required?
             if (cfgFileVer < 30100)         // < 3.1.0
                 conv = CFG_V31;
-            else if (cfgFileVer < 30301)    // < 3.3.1
+            if (cfgFileVer < 30301)         // < 3.3.1
                 conv = CFG_V331;
+            if (cfgFileVer < 30402)         // < 3.4.2: Reset Force FMOD instance = 0
+                conv = CFG_V342;
         }
     }
     
@@ -2122,9 +2124,9 @@ bool DataRefs::LoadConfigFile()
                 switch (conv) {
                     case CFG_NO_CONV:
                         break;
-                    case CFG_V331:
-                    case CFG_V31:
                     case CFG_V3:
+                    case CFG_V31:
+                    case CFG_V331:
                         // We "forgot" to change the default to 49005 for fresh installations,
                         // so we need to convert the port all the way up to v3.3.1:
                         if (*i == DATA_REFS_LT[DR_CFG_RT_TRAFFIC_PORT]) {
@@ -2132,6 +2134,11 @@ bool DataRefs::LoadConfigFile()
                             if (sVal == "49003")
                                 sVal = "49005";
                         }
+                        [[fallthrough]];
+                    case CFG_V342:
+                        // Re-implemented XP Sound, so we reset the "Force own FMOD Instance flag" because we believe in the XP implementation now ;-)
+                        if (*i == DATA_REFS_LT[DR_CFG_SND_FORCE_FMOD_INSTANCE])
+                            sVal = "0";
                         break;
                 }
                 

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -526,6 +526,7 @@ DataRefs::dataRefDefinitionT DATA_REFS_LT[CNT_DATAREFS_LT] = {
     {"livetraffic/cfg/fd_long_refresh_intvl",       DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true, true },
     {"livetraffic/cfg/fd_buf_period",               DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true, true },
     {"livetraffic/cfg/fd_reduce_height",            DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true, true },
+    {"livetraffic/cfg/network_timeout_min",         DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/network_timeout",             DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/lnd_lights_taxi",             DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/hide_below_agl",              DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true, true },
@@ -612,7 +613,8 @@ void* DataRefs::getVarAddr (dataRefsLT dr)
         case DR_CFG_FD_LONG_REFRESH_INTVL:  return &fdLongRefrIntvl;
         case DR_CFG_FD_BUF_PERIOD:          return &fdBufPeriod;
         case DR_CFG_FD_REDUCE_HEIGHT:       return &fdReduceHeight;
-        case DR_CFG_NETW_TIMEOUT:           return &netwTimeout;
+        case DR_CFG_MIN_NETW_TIMEOUT:       return &netwTimeoutMin;
+        case DR_CFG_MAX_NETW_TIMEOUT:       return &netwTimeoutMax;
         case DR_CFG_LND_LIGHTS_TAXI:        return &bLndLightsTaxi;
         case DR_CFG_HIDE_BELOW_AGL:         return &hideBelowAGL;
         case DR_CFG_HIDE_TAXIING:           return &hideTaxiing;
@@ -1709,7 +1711,7 @@ bool DataRefs::SetCfgValue (void* p, int val)
         fdBufPeriod     < fdLongRefrIntvl   || fdBufPeriod      > 180   ||
         fdReduceHeight  < 1000              || fdReduceHeight   > 100000||
         fdSnapTaxiDist  < 0                 || fdSnapTaxiDist   > 50    ||
-        netwTimeout     < 10                ||
+        netwTimeoutMax  < 5                 || netwTimeoutMin   > netwTimeoutMax ||
         hideBelowAGL    < 0                 || hideBelowAGL     > MDL_ALT_MAX ||
         hideNearbyGnd   < 0                 || hideNearbyGnd    > 500   ||
         hideNearbyAir   < 0                 || hideNearbyAir    > 5000  ||
@@ -1776,7 +1778,8 @@ void DataRefs::ResetAdvCfgToDefaults ()
     fdLongRefrIntvl = DEF_FD_LONG_REFR_INTVL;
     fdBufPeriod     = DEF_FD_BUF_PERIOD;
     fdReduceHeight  = DEF_FD_REDUCE_HEIGHT;
-    netwTimeout     = DEF_NETW_TIMEOUT;
+    netwTimeoutMin      = DEF_MIN_NETW_TIMEOUT;
+    netwTimeoutMax      = DEF_MAX_NETW_TIMEOUT;
     contrailAltMin_ft   = DEF_CONTR_ALT_MIN;
     contrailAltMax_ft   = DEF_CONTR_ALT_MAX;
     contrailLifeTime    = DEF_CONTR_LIFETIME;
@@ -2074,7 +2077,7 @@ bool DataRefs::LoadConfigFile()
                 conv = CFG_V31;
             if (cfgFileVer < 30301)         // < 3.3.1
                 conv = CFG_V331;
-            if (cfgFileVer < 30402)         // < 3.4.2: Reset Force FMOD instance = 0
+            if (cfgFileVer < 30402)         // < 3.4.2: Reset Force FMOD instance = 0, set network timeout to 5s
                 conv = CFG_V342;
         }
     }
@@ -2139,6 +2142,9 @@ bool DataRefs::LoadConfigFile()
                         // Re-implemented XP Sound, so we reset the "Force own FMOD Instance flag" because we believe in the XP implementation now ;-)
                         if (*i == DATA_REFS_LT[DR_CFG_SND_FORCE_FMOD_INSTANCE])
                             sVal = "0";
+                        // With OpenSky API timeouts we set the max timeout to just 5s so we try more often
+                        if (*i == DATA_REFS_LT[DR_CFG_MAX_NETW_TIMEOUT])
+                            sVal = "5";
                         break;
                 }
                 

--- a/Src/LTADSBEx.cpp
+++ b/Src/LTADSBEx.cpp
@@ -643,7 +643,7 @@ bool ADSBExchangeConnection::DoTestADSBExAPIKey (const std::string newKey)
     // prepare the handle with the right options
     readBuf.reserve(CURL_MAX_WRITE_SIZE);
     curl_easy_setopt(pCurl, CURLOPT_NOSIGNAL, 1);
-    curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeout());
+    curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeoutMax());
     curl_easy_setopt(pCurl, CURLOPT_ERRORBUFFER, curl_errtxt);
     curl_easy_setopt(pCurl, CURLOPT_HEADERFUNCTION, testKeyTy == ADSBEX_KEY_RAPIDAPI ? ReceiveHeader : NULL);
     curl_easy_setopt(pCurl, CURLOPT_WRITEFUNCTION, DoTestADSBExAPIKeyCB);

--- a/Src/LTADSBHub.cpp
+++ b/Src/LTADSBHub.cpp
@@ -122,7 +122,6 @@ void ADSBHubConnection::StreamMain ()
 #endif
         
         // *** Main Loop ***
-        struct timeval timeout = { ADSBHUB_TIMEOUT_S, 0 };
         while (!bStopThr && tcpStream.isOpen())
         {
             // wait for some signal on either socket (Stream or self-pipe)
@@ -132,6 +131,7 @@ void ADSBHubConnection::StreamMain ()
 #if APL == 1 || LIN == 1
             FD_SET(streamPipe[0], &sRead);              // check the self-pipe
 #endif
+            struct timeval timeout = { ADSBHUB_TIMEOUT_S, 0 };
             int retval = select(maxSock, &sRead, NULL, NULL, &timeout);
             
             // short-cut if we are to shut down (return from 'select' due to closed socket)

--- a/Src/LTOpenGlider.cpp
+++ b/Src/LTOpenGlider.cpp
@@ -926,7 +926,7 @@ static bool OGNAcListDoDownload ()
         // prepare the handle with the right options
         ho.readBuf.reserve(CURL_MAX_WRITE_SIZE);
         curl_easy_setopt(pCurl, CURLOPT_NOSIGNAL, 1);
-        curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeout());
+        curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeoutMax());
         curl_easy_setopt(pCurl, CURLOPT_ERRORBUFFER, curl_errtxt);
         curl_easy_setopt(pCurl, CURLOPT_WRITEFUNCTION, OGNAcListNetwCB);
         curl_easy_setopt(pCurl, CURLOPT_WRITEDATA, &ho);

--- a/Src/LTOpenGlider.cpp
+++ b/Src/LTOpenGlider.cpp
@@ -355,7 +355,6 @@ void OpenGliderConnection::APRSMain (const positionTy& pos, unsigned dist_km)
         }
         
         // *** Main Loop ***
-        struct timeval timeout = { OGN_APRS_TIMEOUT_S, 0 };
         while (!bStopAprs && tcpAprs.isOpen())
         {
             // wait for some signal on either socket (APRS or self-pipe)
@@ -365,6 +364,7 @@ void OpenGliderConnection::APRSMain (const positionTy& pos, unsigned dist_km)
 #if APL == 1 || LIN == 1
             FD_SET(aprsPipe[0], &sRead);              // check the self-pipe
 #endif
+            struct timeval timeout = { OGN_APRS_TIMEOUT_S, 0 };
             int retval = select(maxSock, &sRead, NULL, NULL, &timeout);
             
             // short-cut if we are to shut down (return from 'select' due to closed socket)

--- a/Src/LTOpenSky.cpp
+++ b/Src/LTOpenSky.cpp
@@ -503,7 +503,6 @@ bool OpenSkyAcMasterdata::FetchAllData (const positionTy& /*pos*/)
         if (!info.empty())
             vecAc.push_back(std::move(info));
         
-        IncErrCnt();
         return !listMd.empty();         // return `true` if there is data to process, otherwise we wouldn't process what had been received before the error
     }
     

--- a/Src/LTVersion.cpp
+++ b/Src/LTVersion.cpp
@@ -200,7 +200,7 @@ bool FetchXPlaneOrgVersion ()
     verXPlaneOrg = 0;
     readBuf.reserve(CURL_MAX_WRITE_SIZE);
     curl_easy_setopt(pCurl, CURLOPT_NOSIGNAL, 1);
-    curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeout());
+    curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeoutMax());
     curl_easy_setopt(pCurl, CURLOPT_ERRORBUFFER, curl_errtxt);
     curl_easy_setopt(pCurl, CURLOPT_WRITEFUNCTION, FetchVersionCB);
     curl_easy_setopt(pCurl, CURLOPT_WRITEDATA, &readBuf);

--- a/Src/LTWeather.cpp
+++ b/Src/LTWeather.cpp
@@ -219,7 +219,7 @@ bool WeatherFetch (float _lat, float _lon, float _radius_nm)
             // prepare the handle with the right options
             readBuf.reserve(CURL_MAX_WRITE_SIZE);
             curl_easy_setopt(pCurl, CURLOPT_NOSIGNAL, 1);
-            curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeout());
+            curl_easy_setopt(pCurl, CURLOPT_TIMEOUT, dataRefs.GetNetwTimeoutMax());
             curl_easy_setopt(pCurl, CURLOPT_ERRORBUFFER, curl_errtxt);
             curl_easy_setopt(pCurl, CURLOPT_WRITEFUNCTION, WeatherFetchCB);
             curl_easy_setopt(pCurl, CURLOPT_WRITEDATA, &readBuf);

--- a/Src/LTWeather.cpp
+++ b/Src/LTWeather.cpp
@@ -1,8 +1,8 @@
 /// @file       LTWeather.cpp
 /// @brief      Fetch real weather information from AWC
-/// @see        https://www.aviationweather.gov/dataserver/example?datatype=metar
-/// @see        Example request: Latest weather 25 statute miles around EDLE, limited to the fields we are interested in:
-///             https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&radialDistance=100;-118.9385,33.4036&hoursBeforeNow=2&mostRecent=true&fields=raw_text,station_id,latitude,longitude,altim_in_hg
+/// @see        https://aviationweather.gov/data/api/#/Dataserver/dataserverMetars
+/// @see        Example request: Latest weather somewhere around EDDL, limited to the fields we are interested in:
+///             https://aviationweather.gov//cgi-bin/data/dataserver.php?requestType=retrieve&dataSource=metars&format=xml&boundingBox=45.5,0.5,54.5,9,5&hoursBeforeNow=2&mostRecent=true&fields=raw_text,station_id,latitude,longitude,altim_in_hg
 /// @details    Example response:
 ///                 @code{.xml}
 ///                     <response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XML-Schema-instance" version="1.2" xsi:noNamespaceSchemaLocation="http://aviationweather.gov/adds/schema/metar1_2.xsd">
@@ -52,7 +52,7 @@
 ///                 @endcode
 ///
 /// @author     Birger Hoppe
-/// @copyright  (c) 2018-2020 Birger Hoppe
+/// @copyright  (c) 2018-2023 Birger Hoppe
 /// @copyright  Permission is hereby granted, free of charge, to any person obtaining a
 ///             copy of this software and associated documentation files (the "Software"),
 ///             to deal in the Software without restriction, including without limitation
@@ -76,7 +76,7 @@
 //
 
 /// The request URL, parameters are in this order: radius, longitude, latitude
-const char* WEATHER_URL="https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&minLat=%.2f&minLon=%.2f&maxLat=%.2f&maxLon=%.2f&hoursBeforeNow=2&mostRecent=true&fields=raw_text,station_id,latitude,longitude,altim_in_hg";
+const char* WEATHER_URL="https://aviationweather.gov/cgi-bin/data/dataserver.php?requestType=retrieve&dataSource=metars&format=xml&hoursBeforeNow=2&mostRecent=true&boundingBox=%.2f,%.2f,%.2f,%.2f&fields=raw_text,station_id,latitude,longitude,altim_in_hg";
 
 /// Weather search radius (increment) to use if the initial weather request came back empty
 constexpr float ADD_WEATHER_RADIUS_NM = 100.0f;

--- a/Src/SettingsUI.cpp
+++ b/Src/SettingsUI.cpp
@@ -791,8 +791,9 @@ void LTSettingsUI::buildInterface()
                 ImGui::FilteredCfgNumber("Above height AGL of",    sFilter, DR_CFG_FD_REDUCE_HEIGHT,    1000, 100000, 1000, "%d ft");
                 ImGui::FilteredCfgNumber("increase refresh to",    sFilter, DR_CFG_FD_LONG_REFRESH_INTVL, 10, 180, 5, "%d s");
                 ImGui::FilteredCfgNumber("Buffering period",       sFilter, DR_CFG_FD_BUF_PERIOD,    10, 180, 5, "%d s");
-                ImGui::FilteredCfgNumber("Max. Network timeout",   sFilter, DR_CFG_NETW_TIMEOUT,     10, 180, 5, "%d s");
-            
+                ImGui::FilteredCfgNumber("Min. Network timeout",   sFilter, DR_CFG_MIN_NETW_TIMEOUT,  5, 180, 5, "%d s");
+                ImGui::FilteredCfgNumber("Max. Network timeout",   sFilter, DR_CFG_MAX_NETW_TIMEOUT,  5, 180, 5, "%d s");
+
                 if (!*sFilter) ImGui::TreePop();
             }
 

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -159,6 +159,10 @@
             Fixed <a href="https://github.com/TwinFan/LiveTraffic/issues/258">#258</a>
             extensive logging of ignored OGN messages.
         </li>
+        <li>
+            Linux: Fixed <a href="https://forums.x-plane.org/index.php?/forums/topic/296204-linux-timeouts-from-adsbhub/">ADSBHub and OGN disconnects</a>
+            due to "'select' ran into a timeout"
+        </li>
     </ul>
     
     <h3>v3.4.1</h3>

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -128,12 +128,40 @@
 
     <h2>v3</h2>
 
-    <h3>v3.4.1</h3>
+    <h3>v3.4.2</h3>
 
     <P>
         <b>Update:</b> In case of doubt you can always just copy all files from the archive
         over the files of your existing installation.
     </P>
+
+    <P>At least copy the following files, which have changed compared to v3.4.1:</P>
+    <ul>
+        <li><code>lin|mac|win_x64/LiveTraffic.xpl</code></li>
+    </ul>
+
+    <P>Change log:</P>
+
+    <ul>
+        <li>
+            Reimplemented usage of XP's sound system when running in X-Plane 12.04 and later.
+            As I believe in this implementation, the
+            <a href="https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-advanced#miscellaneous">setting "Own FMOD Instance"</a>
+            is reset to inactive, but is still available and can be
+            activated again in case there are still issues.
+        </li>
+        <li>
+            Fixed <a href="https://github.com/TwinFan/LiveTraffic/issues/257">#257</a>
+            weather download to updated API endpoints so that proper atmospheric pressure
+            can again be applied to altitudes conversion.
+        </li>
+        <li>
+            Fixed <a href="https://github.com/TwinFan/LiveTraffic/issues/258">#258</a>
+            extensive logging of ignored OGN messages.
+        </li>
+    </ul>
+    
+    <h3>v3.4.1</h3>
 
     <P>At least copy the following files, which have changed compared to v3.4.0:</P>
     <ul>

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -144,6 +144,16 @@
 
     <ul>
         <li>
+            In light of OpenSky's API timeout issues, some network error handling
+            is reworked. Introduced a new
+            <a href="https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-advanced#aircraft-selection">Advanced Setting</a>
+            for <i>Min. Network Timeout</i>.
+            With this version, both <i>Min.</i> and <i>Max. Network timeout</i> are set to 5s.
+            This way LiveTraffic won't wait long for OpenSky not responding
+            but instead will retry again sooner.
+            <a href="https://forums.x-plane.org/index.php?/forums/topic/295468-opensky-request-timeouts/&do=findComment&comment=2627189">See here for recommendations.</a>
+        </li>
+        <li>
             Reimplemented usage of XP's sound system when running in X-Plane 12.04 and later.
             As I believe in this implementation, the
             <a href="https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-advanced#miscellaneous">setting "Own FMOD Instance"</a>


### PR DESCRIPTION
- In light of OpenSky's API timeout issues, some network error handling is reworked. Introduced a new [Advanced Setting](https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-advanced#aircraft-selection) for Min. Network Timeout. With this version, both Min. and Max. Network timeout are set to 5s. This way LiveTraffic won't wait long for OpenSky not responding but instead will retry again sooner. [See here for recommendations.](https://forums.x-plane.org/index.php?/forums/topic/295468-opensky-request-timeouts/&do=findComment&comment=2627189)
- Reimplemented usage of XP's sound system when running in X-Plane 12.04 and later. As I believe in this implementation, the [setting "Own FMOD Instance"](https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-advanced#miscellaneous) is reset to inactive, but is still available and can be activated again in case there are still issues.
- Fixed #257 weather download to updated API endpoints so that proper atmospheric pressure can again be applied to altitudes conversion.
- Fixed #258 extensive logging of ignored OGN messages.
- Linux: Fixed [ADSBHub and OGN disconnects](https://forums.x-plane.org/index.php?/forums/topic/296204-linux-timeouts-from-adsbhub/) due to "'select' ran into a timeout"