### PR TITLE
Fix docker windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ endif ()
 
 if (WIN32)
     # Link platform-specific libraries especially for networking
-    target_link_libraries(LiveTraffic ws2_32.lib iphlpapi wldap32.lib advapi32.lib crypt32.lib opengl32 Normaliz)
+    target_link_libraries(LiveTraffic ws2_32.lib iphlpapi wldap32.lib advapi32.lib crypt32.lib opengl32 normaliz)
     if (MINGW)
         # Include MingW threads
         target_link_libraries(LiveTraffic mingw_stdthreads)


### PR DESCRIPTION
I had a linker error while building for windows with docker because of uppercase in the library name.

Tested docker builds with changes:

- [x] lin
- [x] win
- [x] mac-x86
- [x] mac-arm

Blocked by: https://github.com/TwinFan/XPMP2/pull/67