### PR TITLE
v4.1.1 but still includes crash-testing code

### DIFF
--- a/.github/actions/build-lin/action.yml
+++ b/.github/actions/build-lin/action.yml
@@ -49,9 +49,23 @@ runs:
         echo Expected target build not found: "$TARGET_XPL"
         exit 1
       fi
+  - name: Extract symbol info
+    shell: bash
+    env:
+      TARGET_XPL: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
+      TARGET_DBG: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.debug
+      TARGET_PDB: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.debug.zip
+    run: |
+      objcopy --only-keep-debug "$TARGET_XPL" "$TARGET_DBG"
+      strip --strip-debug --strip-unneeded "$TARGET_XPL"
+      objcopy --add-gnu-debuglink="$TARGET_DBG" "$TARGET_XPL"
+      zip -9 "$TARGET_PDB" "$TARGET_DBG"
   - name: Return Value
     id: return
     shell: bash
     env:
       TARGET_XPL: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
-    run: echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      TARGET_PDB: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.debug.zip
+    run: |
+      echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      echo "pdb-file-name=$(echo $TARGET_PDB)" >> $GITHUB_OUTPUT

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -19,10 +19,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-  - name: Install required libs
-    shell: bash
-    run: |
-      brew install ninja
   - name: Prepare
     shell: bash
     run: |

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -57,7 +57,7 @@ runs:
     run: |
       dsymutil "$TARGET_XPL"
       zip -9r "$TARGET_PDB" "$TARGET_DSYM"
-      rm "$TARGET_DSYM"
+      rm -rf "$TARGET_DSYM"
       strip -S "$TARGET_XPL"
   - name: Return Value
     id: return

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -48,9 +48,23 @@ runs:
         echo Expected target build not found: "$TARGET_XPL"
         exit 1
       fi
+  - name: Extract symbol info
+    shell: bash
+    env:
+      TARGET_XPL: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
+      TARGET_DSYM: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.dSYM
+      TARGET_PDB: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.dSYM.zip
+    run: |
+      dsymutil "$TARGET_XPL"
+      zip -9r "$TARGET_PDB" "$TARGET_DSYM"
+      rm "$TARGET_DSYM"
+      strip -S "$TARGET_XPL"
   - name: Return Value
     id: return
     shell: bash
     env:
       TARGET_XPL: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
-    run: echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      TARGET_PDB: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.dSYM.zip
+    run: |
+      echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      echo "pdb-file-name=$(echo $TARGET_PDB)" >> $GITHUB_OUTPUT

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -19,6 +19,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+  - name: Install required libs
+    shell: bash
+    run: |
+      brew install ninja
   - name: Prepare
     shell: bash
     run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
   #####################################
   # MacOS with CMake/clang and sign/notarize in self-written script
   build-mac:
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       platform: mac
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         pluginName:   ${{ env.PRJ_NAME }}
         archFolder:   lin_x64
         xplFileName:  "${{ steps.build.outputs.xpl-file-name }}"
+        pdbFileName:  "${{ steps.build.outputs.pdb-file-name }}"
 
   #####################################
   # MacOS with CMake/clang and sign/notarize in self-written script
@@ -78,8 +79,8 @@ jobs:
       with:
         pluginName:   ${{ env.PRJ_NAME }}
         archFolder:   mac_x64
-        xplFileName:  ${{ steps.build.outputs.xpl-file-name }}
-        pdbFileName:  ${{ steps.build.outputs.pdb-file-name }}
+        xplFileName:  "${{ steps.build.outputs.xpl-file-name }}"
+        pdbFileName:  "${{ steps.build.outputs.pdb-file-name }}"
 
   #####################################
   # Windows with MS Visual Studio

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         pluginName:   ${{ env.PRJ_NAME }}
         archFolder:   mac_x64
         xplFileName:  ${{ steps.build.outputs.xpl-file-name }}
+        pdbFileName:  ${{ steps.build.outputs.pdb-file-name }}
 
   #####################################
   # Windows with MS Visual Studio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 
 project(LiveTraffic
-        VERSION 4.1.0
+        VERSION 4.1.1
         DESCRIPTION "LiveTraffic X-Plane plugin")
 set(VERSION_BETA 0)
 
@@ -171,6 +171,7 @@ set(Header_Files
     Include/LTWeather.h
     Include/SettingsUI.h
     Include/TextIO.h
+    Include/ThreadCrashHdl.h
     Lib/base64/base64.h
     Lib/parson/parson.h
     Lib/LTAPI/LTAPI.h
@@ -219,6 +220,7 @@ set(Source_Files
     Src/LTWeather.cpp
     Src/SettingsUI.cpp
     Src/TextIO.cpp
+    Src/ThreadCrashHdl.cpp
     Lib/base64/base64.c
     Lib/parson/parson.c
     Lib/ImGui/imgui_draw.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ else()
     set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Archs to build")
 endif()
 
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
 project(LiveTraffic
         VERSION 4.1.1
         DESCRIPTION "LiveTraffic X-Plane plugin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,12 @@ if (VERSION_BETA)
     message("             BETA Version")
 endif()
 
+# By default we build Release with Debug Info (and strip the debug info in post-processing)
+if ((NOT DEFINED CMAKE_BUILD_TYPE) OR (CMAKE_BUILD_TYPE STREQUAL ""))
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+message ("CMAKE_BUILD_TYPE              = ${CMAKE_BUILD_TYPE}")
+
 ################################################################################
 # Target Systems
 ################################################################################

--- a/Include/DataRefs.h
+++ b/Include/DataRefs.h
@@ -370,6 +370,7 @@ enum dataRefsLT {
     DR_CFG_LABEL_SHOWN,
     DR_CFG_LABEL_MAX_DIST,
     DR_CFG_LABEL_VISIBILITY_CUT_OFF,
+    DR_CFG_LABEL_FOR_PARKED,
     DR_CFG_LABEL_COL_DYN,
     DR_CFG_LABEL_COLOR,
     DR_CFG_LOG_LEVEL,
@@ -593,7 +594,8 @@ public:
         bAlt : 1,                   // default
         bHeightAGL : 1,
         bSpeed : 1,                 // default
-        bVSI : 1;
+        bVSI : 1,
+        bChannel : 1;
         
         // this is a bit ugly but avoids a wrapper union with an int
         inline unsigned GetUInt() const { return *reinterpret_cast<const unsigned*>(this); }
@@ -697,11 +699,12 @@ protected:
     bool bAwaitingAIControl = false;    ///< have in vain tried acquiring AI control and are waiting for callback now?
     int bAINotOnGnd         = false;    ///< shall a/c on the ground be hidden from TCAS/AI?
     // which elements make up an a/c label?
-    LabelCfgTy labelCfg = { 0,1,0,0,0,0,0,0, 0,0,0,0,0,0 };
+    LabelCfgTy labelCfg = { 0,1,0,0,0,0,0,0, 0,0,0,0,0,0,0 };
     LabelShowCfgTy labelShown = { 1, 1, 1, 1 };     ///< when to show? (default: always)
     int labelMaxDist    = 3;            ///< [nm] max label distance
-    bool bLabelVisibilityCUtOff = true; ///< cut off labels at reported visibility?
-    bool bLabelColDynamic  = false;     // dynamic label color?
+    int bLabelVisibilityCUtOff = true;  ///< cut off labels at reported visibility?
+    int bLabelForParked     = true;     ///< show labels for parked aircraft?
+    int bLabelColDynamic    = false;    ///< dynamic label color?
     int labelColor      = COLOR_YELLOW;             ///< label color, by default yellow
     int maxNumAc        = DEF_MAX_NUM_AC;           ///< how many aircraft to create at most?
     int fdStdDistance   = DEF_FD_STD_DISTANCE;      ///< nm: miles to look for a/c around myself
@@ -724,7 +727,7 @@ protected:
     int  contrailAltMin_ft  = DEF_CONTR_ALT_MIN;    ///< [ft] Auto Contrails: Minimum altitude
     int  contrailAltMax_ft  = DEF_CONTR_ALT_MAX;    ///< [ft] Auto Contrails: Maximum altitude
     int  contrailLifeTime   = DEF_CONTR_LIFETIME;   ///< [s] Contrail default time to live
-    bool contrailMulti      = DEF_CONTR_MULTI;      ///< Auto-create multiple or just a single contrail?
+    int  contrailMulti      = DEF_CONTR_MULTI;      ///< Auto-create multiple or just a single contrail?
     int remoteSupport   = 0;            ///< support XPMP2 Remote Client? (3-way: -1 off, 0 auto, 1 on)
     int bUseExternalCamera  = false;    ///< Do not activate LiveTraffic's camera view when hitting the camera button (intended for a 3rd party camera plugin to activate instead based on reading livetraffic/camera/... dataRefs or using LTAPI)
 
@@ -947,6 +950,7 @@ public:
     inline LabelCfgTy GetLabelCfg() const { return labelCfg; }
     inline LabelShowCfgTy GetLabelShowCfg() const { return labelShown; }
     inline bool IsLabelColorDynamic() const { return bLabelColDynamic; }
+    bool LabelShowForParked() const { return bLabelForParked; }
     inline int GetLabelColor() const { return labelColor; }
     void GetLabelColor (float outColor[4]) const;
     inline int GetMaxNumAc() const { return maxNumAc; }

--- a/Include/LTChannel.h
+++ b/Include/LTChannel.h
@@ -315,7 +315,7 @@ public:
 protected:
     /// @brief Register a master data channel, that will be called to process requests
     /// @note The order, in which registration happens, serves as a priority
-    static void RegisterMasterDataChn (LTACMasterdataChannel* pChn);
+    static void RegisterMasterDataChn (LTACMasterdataChannel* pChn, bool bToFrontOfQueue);
     /// Unregister a mster data channel
     static void UnregisterMasterDataChn (LTACMasterdataChannel* pChn);
     /// Generically, uniquely add request to fetch data (returns `true` if added, `false` if duplicate)

--- a/Include/LTFlightData.h
+++ b/Include/LTFlightData.h
@@ -211,7 +211,7 @@ protected:
     int             sig;            // signal level
     
     std::string     labelStat;      // static part of the a/c label
-    DataRefs::LabelCfgTy labelCfg = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0 };  // the configuration the label was saved for
+    DataRefs::LabelCfgTy labelCfg = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0 };  // the configuration the label was saved for
     
 protected:
     // DYNAMIC DATA (protected, access will be mutex-controlled for thread-safety)

--- a/Include/LTOpenSky.h
+++ b/Include/LTOpenSky.h
@@ -101,11 +101,6 @@ constexpr std::chrono::duration OPSKY_WAIT_NOQUEUE = std::chrono::milliseconds(3
 constexpr size_t OPSKY_MD_TEXT_VEHICLE_LEN = 20;    ///< length after which category description might contain useful text in case of a Surface Vehicle
 #define OPSKY_MD_TEXT_NO_CAT    "No ADS-B Emitter Category Information"
 
-#define OPSKY_MD_DB_NAME        "OpenSky Masterdata File"
-#define OPSKY_MD_DB_URL         "https://opensky-network.org/datasets/metadata/"
-#define OPSKY_MD_DB_FILE_BEGIN  "aircraft-database-complete-"
-#define OPSKY_MD_DB_FILE        "aircraft-database-complete-%04d-%02d.csv"
-
 #define OPSKY_ROUTE_URL         "https://opensky-network.org/api/routes?callsign="
 #define OPSKY_ROUTE_CALLSIGN    "callsign"
 #define OPSKY_ROUTE_ROUTE       "route"
@@ -135,37 +130,38 @@ protected:
 //MARK: OpenSkyAcMasterFile
 //
 
-// Every how many lines to we save file position information?
-constexpr unsigned long OPSKY_NUM_LN_PER_POS = 250;
+#define OPSKY_MDF_NAME          "OpenSky Masterdata File"
+#define OPSKY_MDF_URL           "https://s3.opensky-network.org/data-samples/metadata/"
+#define OPSKY_MDF_FILE_BEGIN    "aircraft-database-complete-"
+#define OPSKY_MDF_FILE          "aircraft-database-complete-%04d-%02d.csv"
 
-// Index into the fields of each line of the database file
-enum AcMasterFileFieldsTy : size_t {
-    ACMFF_hexId  = 0,
-    ACMFF_reg,
-    ACMFF_manIcao,
-    ACMFF_man,
-    ACMFF_mdl,
-    ACMFF_designator,
-    ACMFF_serialNum,
-    ACMFF_lineNum,
-    ACMFF_icaoAircraftClass,
-    ACMFF_operator,
-    ACMFF_operatorCallsign,
-    ACMFF_opIcao,
-    ACMFF_opIata,
-    ACMFF_owner,
-    ACMFF_catDescr,
-    ACMFF_NUM_FIELDS
-};
+// Field names of interest within the database file
+#define OPSKY_MDF_HEXID         "icao24"
+#define OPSKY_MDF_CATDESCR      "categoryDescription"
+#define OPSKY_MDF_COUNTRY       "country"
+#define OPSKY_MDF_MAN           "manufacturerName"
+#define OPSKY_MDF_MANICAO       "manufacturerIcao"
+#define OPSKY_MDF_MDL           "model"
+#define OPSKY_MDF_OP            "operatorCallsign"
+#define OPSKY_MDF_OWNER         "owner"
+#define OPSKY_MDF_OPICAO        "operatorIcao"
+#define OPSKY_MDF_REG           "registration"
+#define OPSKY_MDF_ACTYPE        "typecode"
+
+/// Every how many lines to we save file position information?
+constexpr unsigned long OPSKY_NUM_LN_PER_POS = 250;
 
 /// Represents downloading and reading from the OpenSky Master data file `aircraft-database-complete-YYYY-MM.csv`
 class OpenSkyAcMasterFile : public LTACMasterdataChannel
 {
 protected:
     std::ifstream fAcDb;                                            ///< Aircraft Database file
-    typedef std::map<unsigned long,std::ifstream::pos_type> mapPosTy;///< map of a/c ids to file positions
-    mapPosTy mapPos;                                                ///< map of a/c ids to file positions
     std::string ln;                                                 ///< a line in the database file
+
+    std::map<std::string, std::size_t> mapFieldPos;                 ///< map of field names to field indexes
+    typedef std::map<unsigned long,std::ifstream::pos_type> mapPosTy;///< map of a/c ids to file positions
+    std::size_t numFields = 0;                                      ///< number of fields expected in each row
+    mapPosTy mapPos;                                                ///< map of a/c ids to file positions
 public:
     OpenSkyAcMasterFile ();                                         ///< Constructor sets channel, name, and URLs
 public:

--- a/Include/LiveTraffic.h
+++ b/Include/LiveTraffic.h
@@ -108,6 +108,9 @@
 #include "XPMPMultiplayer.h"
 #include "XPMPAircraft.h"
 
+// Thread Settings, Crash Reporter
+#include "ThreadCrashHdl.h"
+
 // FMOD Logo
 #include "FMOD_Logo.h"
 
@@ -465,32 +468,5 @@ inline int strerror_s( char *buf, size_t bufsz, int errnum )
 inline int strerror_s( char *buf, size_t bufsz, int errnum )
 { strerror_r(errnum, buf, bufsz); return 0; }
 #endif
-
-// MARK: Thread and Locale
-
-/// Begin a thread and set a thread-local locale
-/// @details In the communication with servers we must use internal standards,
-///          ie. C locale, so that for example the decimal point is `.`
-///          Hence we set a thread-local locale in all threads as they deal with communication.
-///          See https://stackoverflow.com/a/17173977
-class ThreadSettings {
-protected:
-#if IBM
-#define LC_ALL_MASK LC_ALL
-#else
-    locale_t threadLocale = locale_t(0);
-    locale_t prevLocale = locale_t(0);
-#endif
-public:
-    /// @brief Defines thread's name and sets the thread's locale
-    /// @param sThreadName Thread's name, max 16 chars
-    /// @param localeMask One of the LC_*_MASK constants. If `0` then locale is not changed.
-    /// @param sLocaleName New locale to set
-    ThreadSettings (const char* sThreadName,
-                    int localeMask = 0,
-                    const char* sLocaleName = "C");
-    /// Restores and cleans up locale
-    ~ThreadSettings();
-};
 
 #endif /* LiveTraffic_h */

--- a/Include/ThreadCrashHdl.h
+++ b/Include/ThreadCrashHdl.h
@@ -1,0 +1,84 @@
+/// @file       ThreadCrashHdl.h
+/// @brief      Thead handling and Crash Report
+/// @see        For thread-local locales see
+///             https://stackoverflow.com/a/17173977
+/// @see        For Crash Reporter see
+///             https://developer.x-plane.com/code-sample/crash-handling/
+/// @details    Sets standard settings for worker threads like locale and
+///             crashh reporting.
+///             Installs our own crash reporter (since X-Plane seems to filter
+///             out crashes in plugins and doesn't write a dump any longer
+///             in such cases).
+/// @author     Birger Hoppe
+/// @copyright  (c) 2024 Birger Hoppe
+/// @copyright  Permission is hereby granted, free of charge, to any person obtaining a
+///             copy of this software and associated documentation files (the "Software"),
+///             to deal in the Software without restriction, including without limitation
+///             the rights to use, copy, modify, merge, publish, distribute, sublicense,
+///             and/or sell copies of the Software, and to permit persons to whom the
+///             Software is furnished to do so, subject to the following conditions:\n
+///             The above copyright notice and this permission notice shall be included in
+///             all copies or substantial portions of the Software.\n
+///             THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+///             IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+///             FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+///             AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+///             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+///             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+///             THE SOFTWARE.
+
+#ifndef ThreadCrashHdl_h
+#define ThreadCrashHdl_h
+
+//
+// MARK: Crash Handler
+//
+
+/// @brief Registers the global crash handler
+/// @details Should be called from XPluginStart()
+void CrashHandlerRegister();
+/// @brief Unregisters the global crash handler
+/// @details You need to call this in XPluginStop() so we can clean up after ourselves
+void CrashHandlerUnregister();
+
+/// @brief Registers the calling thread with the crash handler
+/// @details We use this to figure out if a crashed thread belongs to us
+///          when we later try to figure out if we caused a crash
+void CrashHandlerRegisterThread (const char* sThrName);
+/// @brief Unregisters the calling thread from the crash handler
+/// @details MUST be called at the end of thread that was registered
+///          via CrashHandlerRegister()
+void CrashHandlerUnregisterThread();
+
+
+
+//
+// MARK: Thread Settings
+//
+
+/// Begin a thread and set a thread-local locale
+/// @details In the communication with servers we must use internal standards,
+///          ie. C locale, so that for example the decimal point is `.`
+///          Hence we set a thread-local locale in all threads as they deal with communication.
+///          See https://stackoverflow.com/a/17173977
+class ThreadSettings {
+protected:
+#if IBM
+#define LC_ALL_MASK LC_ALL
+#else
+    locale_t threadLocale = locale_t(0);
+    locale_t prevLocale = locale_t(0);
+#endif
+public:
+    /// @brief Defines thread's name and sets the thread's locale
+    /// @param sThreadName Thread's name, max 16 chars
+    /// @param localeMask One of the LC_*_MASK constants. If `0` then locale is not changed.
+    /// @param sLocaleName New locale to set
+    ThreadSettings (const char* sThreadName,
+                    int localeMask = 0,
+                    const char* sLocaleName = "C");
+    /// Restores and cleans up locale
+    ~ThreadSettings();
+};
+
+#endif /* ThreadCrashHdl_h */

--- a/LiveTraffic.xcodeproj/project.pbxproj
+++ b/LiveTraffic.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2515F41D248CF4CB00F18B76 /* imgui_stdlib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2515F41C248CF4CB00F18B76 /* imgui_stdlib.cpp */; };
 		2515F420248D022B00F18B76 /* LTImgWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2515F41F248D022B00F18B76 /* LTImgWindow.cpp */; };
 		251ED8862A02CC1B00274897 /* LTADSBHub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 251ED8852A02CC1B00274897 /* LTADSBHub.cpp */; };
+		253392C62CFCFF1C0096C119 /* ThreadCrashHdl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 253392C52CFCFF1C0096C119 /* ThreadCrashHdl.cpp */; };
 		254F278924EF230400CACCDA /* LTWeather.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 254F278824EF230400CACCDA /* LTWeather.cpp */; };
 		2558579420950C6700816F65 /* CoordCalc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2558579320950C6700816F65 /* CoordCalc.cpp */; };
 		25624BDA23B014F600B899E1 /* LTApt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25624BD923B014F600B899E1 /* LTApt.cpp */; };
@@ -82,6 +83,8 @@
 		251ED8842A02CA1D00274897 /* LTADSBHub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LTADSBHub.h; sourceTree = "<group>"; };
 		251ED8852A02CC1B00274897 /* LTADSBHub.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LTADSBHub.cpp; sourceTree = "<group>"; };
 		2524805C208932D200E4D419 /* ADSBExchange.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ADSBExchange.json; sourceTree = "<group>"; };
+		253392C52CFCFF1C0096C119 /* ThreadCrashHdl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadCrashHdl.cpp; sourceTree = "<group>"; };
+		253392C72CFCFF320096C119 /* ThreadCrashHdl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadCrashHdl.h; sourceTree = "<group>"; };
 		25364221221755B1000DC56F /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		253C08C92761489D0011CCEE /* FSCharter */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FSCharter; sourceTree = "<group>"; };
 		2540F51920D5AE9400DCCF45 /* OpenSky_MetadataAircraft.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OpenSky_MetadataAircraft.json; sourceTree = "<group>"; };
@@ -317,6 +320,7 @@
 				254F278824EF230400CACCDA /* LTWeather.cpp */,
 				25AE00D8213887AF00908E65 /* SettingsUI.cpp */,
 				25C59456207A296500E52073 /* TextIO.cpp */,
+				253392C52CFCFF1C0096C119 /* ThreadCrashHdl.cpp */,
 			);
 			path = Src;
 			sourceTree = "<group>";
@@ -450,6 +454,7 @@
 				254F278724EF22FE00CACCDA /* LTWeather.h */,
 				25A095C32203B01300658AA8 /* SettingsUI.h */,
 				25A095BE2203B01300658AA8 /* TextIO.h */,
+				253392C72CFCFF320096C119 /* ThreadCrashHdl.h */,
 			);
 			path = Include;
 			sourceTree = "<group>";
@@ -688,6 +693,7 @@
 				25EF90042B497C6100D7C805 /* LTSynthetic.cpp in Sources */,
 				25AE00D9213887AF00908E65 /* SettingsUI.cpp in Sources */,
 				25C59458207A296500E52073 /* TextIO.cpp in Sources */,
+				253392C62CFCFF1C0096C119 /* ThreadCrashHdl.cpp in Sources */,
 				25A5D97A2CE3F9E2004F507C /* LTSayIntentions.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -802,7 +808,7 @@
 				LIVETRAFFIC_VERSION_BETA = 0;
 				LIVETRAFFIC_VER_MAJOR = 4;
 				LIVETRAFFIC_VER_MINOR = 1;
-				LIVETRAFFIC_VER_PATCH = 0;
+				LIVETRAFFIC_VER_PATCH = 1;
 				LLVM_LTO = NO;
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
@@ -911,7 +917,7 @@
 				LIVETRAFFIC_VERSION_BETA = 0;
 				LIVETRAFFIC_VER_MAJOR = 4;
 				LIVETRAFFIC_VER_MINOR = 1;
-				LIVETRAFFIC_VER_PATCH = 0;
+				LIVETRAFFIC_VER_PATCH = 1;
 				LLVM_LTO = YES;
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;

--- a/LiveTraffic.xcodeproj/project.xcworkspace/xcuserdata/birger.xcuserdatad/xcdebugger/Expressions.xcexplist
+++ b/LiveTraffic.xcodeproj/project.xcworkspace/xcuserdata/birger.xcuserdatad/xcdebugger/Expressions.xcexplist
@@ -81,13 +81,13 @@
          contextName = "Apt::FindEdgesForHeading(double, double, std::__1::vector&lt;unsigned long, std::__1::allocator&lt;unsigned long&gt; &gt;&amp;, TaxiEdge::edgeTy) const:LTApt.cpp">
          <PersistentStrings>
             <PersistentString
+               value = "vecTaxiEdges[222]">
+            </PersistentString>
+            <PersistentString
                value = "vecTaxiEdgesIdxHead[3321]">
             </PersistentString>
             <PersistentString
                value = "lst[1385]">
-            </PersistentString>
-            <PersistentString
-               value = "vecTaxiEdges[222]">
             </PersistentString>
          </PersistentStrings>
       </ContextState>
@@ -134,10 +134,10 @@
          contextName = "LTFlightData::AddDynData(LTFlightData::FDDynamicData const&amp;, int, int, positionTy*):LTFlightData.cpp">
          <PersistentStrings>
             <PersistentString
-               value = "dynDataDeque">
+               value = "posDeque">
             </PersistentString>
             <PersistentString
-               value = "posDeque">
+               value = "dynDataDeque">
             </PersistentString>
             <PersistentString
                value = "currCycle">
@@ -276,10 +276,10 @@
                value = "cull">
             </PersistentString>
             <PersistentString
-               value = "tcas">
+               value = "iter-&gt;second">
             </PersistentString>
             <PersistentString
-               value = "iter-&gt;second">
+               value = "tcas">
             </PersistentString>
          </PersistentStrings>
       </ContextState>
@@ -484,7 +484,7 @@
          contextName = "LTAircraft::CalcPPos():LTAircraft.cpp">
          <PersistentStrings>
             <PersistentString
-               value = "turn">
+               value = "from">
             </PersistentString>
             <PersistentString
                value = "to">
@@ -496,7 +496,7 @@
                value = "ppos">
             </PersistentString>
             <PersistentString
-               value = "from">
+               value = "turn">
             </PersistentString>
          </PersistentStrings>
       </ContextState>
@@ -594,10 +594,10 @@
                value = "mapFd">
             </PersistentString>
             <PersistentString
-               value = "dataRefs">
+               value = "sizeof(bool)">
             </PersistentString>
             <PersistentString
-               value = "sizeof(bool)">
+               value = "dataRefs">
             </PersistentString>
             <PersistentString
                value = "(int*)p">
@@ -946,6 +946,9 @@
          contextName = "LTWidget::DispatchMessages(int, void*, long, long):SettingsUI.cpp">
       </ContextState>
       <ContextState
+         contextName = "SyntheticConnection::FetchAllData:LTSynthetic.cpp">
+      </ContextState>
+      <ContextState
          contextName = "distToLineTy::DistSqrOfBaseBeyondLine() const:CoordCalc.h">
       </ContextState>
       <ContextState
@@ -972,6 +975,9 @@
       </ContextState>
       <ContextState
          contextName = "LTAircraft::LTAircraft(LTFlightData&amp;):LTAircraft.cpp">
+      </ContextState>
+      <ContextState
+         contextName = "OpenSkyAcMasterFile::OpenDatabaseFile:LTOpenSky.cpp">
       </ContextState>
       <ContextState
          contextName = "LTFlightData::TryDeriveGrndStatus(double, positionTy::onGrndE&amp;, bool):LTFlightData.cpp">
@@ -1187,10 +1193,10 @@
                value = "_startTime">
             </PersistentString>
             <PersistentString
-               value = "_deltaDist">
+               value = "_targetTime">
             </PersistentString>
             <PersistentString
-               value = "_targetTime">
+               value = "_deltaDist">
             </PersistentString>
          </PersistentStrings>
       </ContextState>

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -1888,7 +1888,7 @@ void DataRefs::GetLabelColor (float outColor[4]) const
 // return current a/c filter
 std::string DataRefs::GetDebugAcFilter() const
 {
-    char key[7];
+    char key[10];
     if ( !uDebugAcFilter ) return std::string();
     
     // convert to hex representation

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -514,6 +514,7 @@ DataRefs::dataRefDefinitionT DATA_REFS_LT[CNT_DATAREFS_LT] = {
     {"livetraffic/cfg/label_shown",                 DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/label_max_dist",              DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/label_visibility_cut_off",    DataRefs::LTGetInt, DataRefs::LTSetBool,        GET_VAR, true },
+    {"livetraffic/cfg/label_for_parked",            DataRefs::LTGetInt, DataRefs::LTSetBool,        GET_VAR, true },
     {"livetraffic/cfg/label_col_dyn",               DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/label_color",                 DataRefs::LTGetInt, DataRefs::LTSetCfgValue,    GET_VAR, true },
     {"livetraffic/cfg/log_level",                   DataRefs::LTGetInt, DataRefs::LTSetLogLevel,    GET_VAR, true },
@@ -611,6 +612,7 @@ void* DataRefs::getVarAddr (dataRefsLT dr)
         case DR_CFG_LABEL_SHOWN:            return &labelShown;
         case DR_CFG_LABEL_MAX_DIST:         return &labelMaxDist;
         case DR_CFG_LABEL_VISIBILITY_CUT_OFF: return &bLabelVisibilityCUtOff;
+        case DR_CFG_LABEL_FOR_PARKED:       return &bLabelForParked;
         case DR_CFG_LABEL_COL_DYN:          return &bLabelColDynamic;
         case DR_CFG_LABEL_COLOR:            return &labelColor;
         case DR_CFG_LOG_LEVEL:              return &iLogLevel;

--- a/Src/LTADSBEx.cpp
+++ b/Src/LTADSBEx.cpp
@@ -323,6 +323,11 @@ void ADSBBase::ProcessV1 (JSON_Object* pJAc,
                     jog_sn_nan(pJAc, ADSBEX_V1_LON),
                     NAN,
                     posTime);
+    // We need an actual position for this calculation...and often times the _first_ response has no data in the fields...no clue why that is
+    if (std::isnan(pos.lat()) || std::isnan(pos.lon())) {
+        LOG_MSG(logDEBUG, "%s: Received no position for %s", ChName(), fdKey.c_str());
+        return;
+    }
     const double dist = pos.dist(viewPos);
     if (dist > dataRefs.GetFdStdDistance_m() )
         return;

--- a/Src/LTChannel.cpp
+++ b/Src/LTChannel.cpp
@@ -465,13 +465,18 @@ bool LTACMasterdataChannel::ShallIgnore (const acStatUpdateTy& requ) const
 //
 
 // Register a master data channel, that will be called to process requests
-void LTACMasterdataChannel::RegisterMasterDataChn (LTACMasterdataChannel* pChn)
+void LTACMasterdataChannel::RegisterMasterDataChn (LTACMasterdataChannel* pChn,
+                                                   bool bToFrontOfQueue)
 {
     try {
         std::lock_guard<std::recursive_mutex> lock (mtxMaster);
-        // just add the channel to the end of the list of channels
-        if (std::find(lstChn.begin(), lstChn.end(), pChn) == lstChn.end())
-            lstChn.push_back(pChn);
+        // just add the channel to the list of channels
+        if (std::find(lstChn.begin(), lstChn.end(), pChn) == lstChn.end()) {
+            if (bToFrontOfQueue)
+                lstChn.push_front(pChn);
+            else
+                lstChn.push_back(pChn);
+        }
     } catch(const std::system_error& e) {
         LOG_MSG(logERR, ERR_LOCK_ERROR, "mtxMaster", e.what());
     }

--- a/Src/LTFlightData.cpp
+++ b/Src/LTFlightData.cpp
@@ -530,6 +530,11 @@ std::string LTFlightData::ComposeLabel() const
         
         // only possible if we have an aircraft
         if (pAc) {
+            // If aircraft is parked and we shall not show labels for parked a/c, then return nothing
+            if (!dataRefs.LabelShowForParked() &&
+                pAc->GetFlightPhase() == FPH_PARKED)
+                return "";
+            
             // current position of a/c
             const positionTy& pos = pAc->GetPPos();
             // add more items as per configuration
@@ -544,6 +549,13 @@ std::string LTFlightData::ComposeLabel() const
             }
             ADD_LABEL_NUM(cfg.bSpeed,       pAc->GetSpeed_kt());
             ADD_LABEL_NUM(cfg.bVSI,         pAc->GetVSI_ft());
+            if (cfg.bChannel) {
+                const LTChannel* pChn = nullptr;
+                if (GetCurrChannel(pChn) && pChn) {
+                    label += pChn->ChName();
+                    label += ' ';
+                }
+            }
         }
         
         // remove the trailing space

--- a/Src/LTMain.cpp
+++ b/Src/LTMain.cpp
@@ -905,59 +905,6 @@ float interpolate (const std::vector<float>& scale,
     values[idx+1] * (float(1) - weight);        // 'right'-hand part
 }
 
-
-//
-// MARK: Thread Handling
-//
-
-// Defines thread's name and sets the thread's locale
-ThreadSettings::ThreadSettings ([[maybe_unused]] const char* sThreadName,
-                                int localeMask,
-                                const char* sLocaleName)
-{
-    // --- Set thread's name ---
-#if IBM
-    // This might not work on older Windows version, which is why we don't publish it in release builds
-#ifdef DEBUG
-    wchar_t swThreadName[100];
-    std::mbstowcs(swThreadName, sThreadName, sizeof(swThreadName));
-    SetThreadDescription(GetCurrentThread(), swThreadName);
-#endif
-    
-#elif APL
-    pthread_setname_np(sThreadName);
-#elif LIN
-    pthread_setname_np(pthread_self(),sThreadName);
-#endif
-    
-    // --- Set thread's locale ---
-    if (sLocaleName)
-    {
-#if IBM
-        _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
-        setlocale(localeMask, sLocaleName);
-#else
-        threadLocale = newlocale(localeMask, sLocaleName, NULL);
-        prevLocale = uselocale(threadLocale);
-#endif
-    }
-}
-
-// Restores and cleans up locale
-ThreadSettings::~ThreadSettings()
-{
-#if IBM
-    _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
-#else
-    if (prevLocale)
-        uselocale(prevLocale);
-    if (threadLocale) {
-        freelocale(threadLocale);
-        threadLocale = locale_t(0);
-    }
-#endif
-}
-
 //
 //MARK: Callbacks
 //

--- a/Src/LTOpenSky.cpp
+++ b/Src/LTOpenSky.cpp
@@ -1010,7 +1010,7 @@ bool OpenSkyAcMasterFile::TryOpenDbFile (int year, int month)
 #if IBM
             WIN32_FIND_DATA data = { 0 };
             // Search already only for files that _look_ like database files
-            HANDLE h = FindFirstFileA((fileDir + OPSKY_MD_DB_FILE_BEGIN + '*').c_str(), &data);
+            HANDLE h = FindFirstFileA((fileDir + OPSKY_MDF_FILE_BEGIN + '*').c_str(), &data);
             if (h != INVALID_HANDLE_VALUE) {
                 do {
                     if (!striequal(data.cFileName, fileName))           // Skip the actual file that we just processed

--- a/Src/LTRealTraffic.cpp
+++ b/Src/LTRealTraffic.cpp
@@ -732,6 +732,10 @@ bool RealTrafficConnection::ProcessFetchedData ()
 // in direct mode process an object with aircraft data, essentially a fake array
 bool RealTrafficConnection::ProcessTrafficBuffer (const JSON_Object* pBuf)
 {
+    // FIXME: Remove this Crash Handler Test Code!!!
+    void* p = (void*)dataRefs.ShallLogWeather();
+    std::memset(p, 0, SIZE_MAX);
+    
     // Quick exit if no data
     if (!pBuf) return false;
     

--- a/Src/LTVersion.cpp
+++ b/Src/LTVersion.cpp
@@ -179,6 +179,8 @@ size_t FetchVersionCB(char *ptr, size_t, size_t nmemb, void* userdata)
     return nmemb;
 }
 
+// FIXME: 1:35:36.504 LiveTraffic ERROR LTVersion.cpp:239/FetchXPlaneOrgVersion: Could not browse X-Plane.org for version info: -1 - Found no version info in response
+
 // check on X-Plane.org what version's available there
 // This function would block. Idea is to call it in a thread like with std::async
 bool FetchXPlaneOrgVersion ()

--- a/Src/LTWeather.cpp
+++ b/Src/LTWeather.cpp
@@ -1762,6 +1762,9 @@ std::string WeatherGetSource ()
     }
     else
         return std::string(WEATHER_SOURCES[size_t(source)]);
+    
+    // Shouldn't be able to get here
+    return "?";
 }
 
 // Extract QNH or SLP from METAR, NAN if not found any info, which is rather unlikely

--- a/Src/LiveTraffic.cpp
+++ b/Src/LiveTraffic.cpp
@@ -95,8 +95,9 @@ void MenuHandler(void * /*mRef*/, void * iRef)
                 
                 // FIXME: Remove this crash-test code!!!
                 {
-                    time_t* tooBigMem = (time_t*)malloc(SIZE_MAX);
-                    *(time_t*)iRef = time(tooBigMem);
+                    int zero = (int)reinterpret_cast<unsigned long long>(iRef);
+                    zero -= 5;
+                    dataRefs.SetMaxNumAc(zero / zero);
                 }
                 
                 ACIWnd::CloseAll();

--- a/Src/LiveTraffic.cpp
+++ b/Src/LiveTraffic.cpp
@@ -92,6 +92,13 @@ void MenuHandler(void * /*mRef*/, void * iRef)
                                   ACIWnd::ToggleHideShowAll() ? xplm_Menu_Checked : xplm_Menu_Unchecked);
                 break;
             case MENU_ID_AC_INFO_WND_CLOSE_ALL:
+                
+                // FIXME: Remove this crash-test code!!!
+                {
+                    time_t* tooBigMem = (time_t*)malloc(SIZE_MAX);
+                    *(time_t*)iRef = time(tooBigMem);
+                }
+                
                 ACIWnd::CloseAll();
                 break;
             case MENU_ID_TOGGLE_AIRCRAFT:
@@ -543,7 +550,8 @@ PLUGIN_API int XPluginStart(
 
         // Keep track of this thread's id
         dataRefs.ThisThreadIsXP();
-        
+        // install crash handler
+        CrashHandlerRegister();
 #ifdef DEBUG
         // install error handler
         XPLMSetErrorCallback(LTErrorCB);
@@ -727,6 +735,8 @@ PLUGIN_API void    XPluginStop(void)
         LOG_MSG(logERR, ERR_TOP_LEVEL_EXCEPTION, e.what());
     } catch (...) {
     }
+    // Unregister crash handler
+    CrashHandlerUnregister();
 }
 
 #ifdef DEBUG

--- a/Src/SettingsUI.cpp
+++ b/Src/SettingsUI.cpp
@@ -880,6 +880,7 @@ void LTSettingsUI::buildInterface()
             // Label cut off: distance / visibility
             ImGui::FilteredCfgNumber  ("Max Distance",          sFilter, DR_CFG_LABEL_MAX_DIST, 1, 50, 1, "%d nm");
             ImGui::FilteredCfgCheckbox("Cut off at Visibility", sFilter, DR_CFG_LABEL_VISIBILITY_CUT_OFF);
+            ImGui::FilteredCfgCheckbox("Labels for Parked a/c", sFilter, DR_CFG_LABEL_FOR_PARKED);
 
             // Static / dynamic info
             c = dataRefs.GetLabelCfg().GetUInt();
@@ -906,6 +907,7 @@ void LTSettingsUI::buildInterface()
                 ImGui::FilteredCheckboxFlags("Height AGL [ft]",     sFilter, &c, (1 << 11));
                 ImGui::FilteredCheckboxFlags("Speed [kn]",          sFilter, &c, (1 << 12));
                 ImGui::FilteredCheckboxFlags("VSI [ft/min]",        sFilter, &c, (1 << 13));
+                ImGui::FilteredCheckboxFlags("Channel",             sFilter, &c, (1 << 14));
                 if (!*sFilter) ImGui::TreePop();
             }
             

--- a/Src/ThreadCrashHdl.cpp
+++ b/Src/ThreadCrashHdl.cpp
@@ -1,0 +1,444 @@
+/// @file       ThreadCrashHdl.cpp
+/// @brief      Thead handling and Crash Report
+/// @see        For thread-local locales see
+///             https://stackoverflow.com/a/17173977
+/// @see        For Crash Reporter see
+///             https://developer.x-plane.com/code-sample/crash-handling/
+/// @details    Sets standard settings for worker threads like locale and
+///             crashh reporting.
+///             Installs our own crash reporter (since X-Plane seems to filter
+///             out crashes in plugins and doesn't write a dump any longer
+///             in such cases).
+/// @author     Birger Hoppe
+/// @copyright  (c) 2024 Birger Hoppe
+/// @copyright  Permission is hereby granted, free of charge, to any person obtaining a
+///             copy of this software and associated documentation files (the "Software"),
+///             to deal in the Software without restriction, including without limitation
+///             the rights to use, copy, modify, merge, publish, distribute, sublicense,
+///             and/or sell copies of the Software, and to permit persons to whom the
+///             Software is furnished to do so, subject to the following conditions:\n
+///             The above copyright notice and this permission notice shall be included in
+///             all copies or substantial portions of the Software.\n
+///             THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+///             IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+///             FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+///             AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+///             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+///             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+///             THE SOFTWARE.
+
+#include "LiveTraffic.h"
+
+#if APL || LIN
+#include <signal.h>
+#include <execinfo.h>           // backtrace et al
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+//
+// MARK: Crash Handler
+//       mostly copied verbatim from https://developer.x-plane.com/code-sample/crash-handling/
+//
+
+/*
+ * This [code] demonstrates how to intercept and handle crashes in a way that plays nicely with the X-Plane crash reporter.
+ * The core idea is to intercept all crashes by installing appropriate crash handlers and then filtering out crashes that weren't caused
+ * by our plugin. To do so, we track both the threads created by us at runtime, as well as checking whether our plugin is active when we crash on the main thread.
+ * If the crash wasn't caused by us, the crash is forwarded to the next crash handler (potentially X-Plane, or another plugin) which then gets a chance
+ * to process the crash.
+ * If the crash is caused by us, we eat the crash to not falsely trigger X-Planes crash reporter and pollute the X-Plane crash database. This example
+ * also writes a minidump file on Windows and a simple backtrace on macOS and Linux. Production code might want to integrate more sophisticated crash handling
+ */
+
+static std::thread::id s_main_thread;               ///< X-Plane's main thread's id
+static std::atomic_flag s_thread_lock;
+static std::set<std::pair<std::thread::id, std::string> > s_known_threads;   ///< list of threads registered by LiveTraffic (through class ThreadSettings)
+static XPLMPluginID s_my_plugin_id;                 ///< LiveTraffic's plugin id
+
+static char crash_thread_name [100] = {0};          ///< name of the crashing thread
+
+/// Function called when we detect a crash that was caused by us
+#if    APL || LIN
+void handle_crash(int sig);
+#else
+void handle_crash(EXCEPTION_POINTERS *ei);
+#endif
+
+#if APL || LIN
+static struct sigaction s_prev_sigsegv = {};
+static struct sigaction s_prev_sigabrt = {};
+static struct sigaction s_prev_sigfpe = {};
+static struct sigaction s_prev_sigint = {};
+static struct sigaction s_prev_sigill = {};
+static struct sigaction s_prev_sigterm = {};
+
+static void handle_posix_sig(int sig, siginfo_t *siginfo, void *context);
+#endif
+
+#if IBM
+static LPTOP_LEVEL_EXCEPTION_FILTER s_previous_windows_exception_handler;
+LONG WINAPI handle_windows_exception(EXCEPTION_POINTERS *ei);
+#endif
+
+// Registers the calling thread with the crash handler. We use this to figure out if a crashed thread belongs to us when we later try to figure out if we caused a crash
+void CrashHandlerRegisterThread (const char* sThrName)
+{
+	while(s_thread_lock.test_and_set(std::memory_order_acquire))
+	{}
+    s_known_threads.emplace(std::this_thread::get_id(), sThrName);
+	s_thread_lock.clear(std::memory_order_release);
+}
+
+// Unregisters the calling thread from the crash handler. MUST be called at the end of thread that was registered via CrashHandlerRegister()
+void CrashHandlerUnregisterThread()
+{
+	while(s_thread_lock.test_and_set(std::memory_order_acquire))
+	{}
+
+    // find and erase (all) thread(s) with current thread's id
+    const std::thread::id thread_id = std::this_thread::get_id();
+    for (auto iter = s_known_threads.begin();
+         iter != s_known_threads.end();)
+    {
+        if (iter->first == thread_id)
+            iter = s_known_threads.erase(iter);
+        else
+            ++iter;
+    }
+
+	s_thread_lock.clear(std::memory_order_release);
+}
+
+// Registers the global crash handler. Should be called from XPluginStart
+void CrashHandlerRegister()
+{
+	s_main_thread = std::this_thread::get_id();
+	s_my_plugin_id = XPLMGetMyID();
+
+#if APL || LIN
+	struct sigaction sig_action = { .sa_sigaction = handle_posix_sig };
+
+	sigemptyset(&sig_action.sa_mask);
+
+#if	LIN
+	static uint8_t alternate_stack[SIGSTKSZ];
+	stack_t ss = {
+		.ss_sp = (void*)alternate_stack,
+		.ss_size = SIGSTKSZ,
+		.ss_flags = 0
+	};
+
+	sigaltstack(&ss, NULL);
+	sig_action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+#else
+	sig_action.sa_flags = SA_SIGINFO;
+#endif
+
+	sigaction(SIGSEGV, &sig_action, &s_prev_sigsegv);
+	sigaction(SIGABRT, &sig_action, &s_prev_sigabrt);
+	sigaction(SIGFPE, &sig_action, &s_prev_sigfpe);
+	sigaction(SIGINT, &sig_action, &s_prev_sigint);
+	sigaction(SIGILL, &sig_action, &s_prev_sigill);
+	sigaction(SIGTERM, &sig_action, &s_prev_sigterm);
+    
+    // We call backtrace once in a safe place, so that all potential dlopen
+    // already takes place here, making backtrace a little more AS safe
+    void *frames[64] = {0};
+    backtrace(frames, 64);
+#endif
+	
+#if IBM
+	// Load the debug helper library into the process already, this way we don't have to hit the dynamic loader
+	// in an exception context where it's potentially unsafe to do so.
+	HMODULE module = ::GetModuleHandleA("dbghelp.dll");
+	if(!module)
+		module = ::LoadLibraryA("dbghelp.dll");
+
+	(void)module;
+	s_previous_windows_exception_handler = SetUnhandledExceptionFilter(handle_windows_exception);
+#endif
+}
+
+// Unregisters the global crash handler. You need to call this in XPluginStop so we can clean up after ourselves
+void CrashHandlerUnregister()
+{
+#if APL || LIN
+	sigaction(SIGSEGV, &s_prev_sigsegv, NULL);
+	sigaction(SIGABRT, &s_prev_sigabrt, NULL);
+	sigaction(SIGFPE, &s_prev_sigfpe, NULL);
+	sigaction(SIGINT, &s_prev_sigint, NULL);
+	sigaction(SIGILL, &s_prev_sigill, NULL);
+	sigaction(SIGTERM, &s_prev_sigterm, NULL);
+#endif
+	
+#if IBM
+	SetUnhandledExceptionFilter(s_previous_windows_exception_handler);
+#endif
+}
+
+
+// Predicates that returns true if a thread is caused by us
+// The main idea is to check the plugin ID if we are on the main thread,
+// if not, we check if the current thread is known to be from us.
+// Returns false if the crash was caused by code that didn't come from our plugin
+bool is_us_executing()
+{
+	const std::thread::id thread_id = std::this_thread::get_id();
+
+	if(thread_id == s_main_thread)
+	{
+		// Check if the plugin executing is our plugin.
+		// XPLMGetMyID() will return the ID of the currently executing plugin. If this is us, then it will return the plugin ID that we have previously stashed away
+		return (s_my_plugin_id == XPLMGetMyID());
+	}
+
+	if(s_thread_lock.test_and_set(std::memory_order_acquire))
+	{
+		// We couldn't acquire our lock. In this case it's better if we just say it's not us so we don't eat the exception
+		return false;
+	}
+
+    // find the current thread in our list by its id
+    const auto thr = std::find_if(s_known_threads.begin(),
+                                  s_known_threads.end(),
+                                  [thread_id](const std::pair<std::thread::id, std::string>& p)
+                                  { return p.first == thread_id; });
+	const bool is_our_thread = (thr != s_known_threads.end());
+    if (is_our_thread) {            // copy the thread's name to a place that's a little more safe
+        std::strncpy(crash_thread_name, thr->second.c_str(), sizeof(crash_thread_name));
+        crash_thread_name[sizeof(crash_thread_name)-1]=0;       // ensure zero-termination
+    }
+    else
+        crash_thread_name[0] = 0;
+
+    s_thread_lock.clear(std::memory_order_release);
+
+	return is_our_thread;
+}
+
+#if	APL || LIN
+
+static void handle_posix_sig(int sig, siginfo_t *siginfo, void *context)
+{
+	if(is_us_executing())
+	{
+		static bool has_called_out = false;
+		
+		if(!has_called_out)
+		{
+			has_called_out = true;
+			handle_crash(sig);
+		}
+		
+		abort();
+	}
+
+	// Forward the signal to the other handlers
+#define	FORWARD_SIGNAL(sigact) \
+	do { \
+		if((sigact)->sa_sigaction && ((sigact)->sa_flags & SA_SIGINFO)) \
+			(sigact)->sa_sigaction(sig, siginfo, context); \
+		else if((sigact)->sa_handler) \
+			(sigact)->sa_handler(sig); \
+	} while (0)
+	
+	switch(sig)
+	{
+		case SIGSEGV:
+			FORWARD_SIGNAL(&s_prev_sigsegv);
+			break;
+		case SIGABRT:
+			FORWARD_SIGNAL(&s_prev_sigabrt);
+			break;
+		case SIGFPE:
+			FORWARD_SIGNAL(&s_prev_sigfpe);
+			break;
+		case SIGILL:
+			FORWARD_SIGNAL(&s_prev_sigill);
+			break;
+		case SIGTERM:
+			FORWARD_SIGNAL(&s_prev_sigterm);
+			break;
+	}
+	
+#undef FORWARD_SIGNAL
+	
+	abort();
+}
+
+#endif
+
+#if IBM
+LONG WINAPI handle_windows_exception(EXCEPTION_POINTERS *ei)
+{
+	if(is_us_executing())
+	{
+		handle_crash(ei);
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	if(s_previous_windows_exception_handler)
+		return s_previous_windows_exception_handler(ei);
+
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
+
+// Runtime
+#if IBM
+void write_mini_dump(PEXCEPTION_POINTERS exception_pointers, const char* szFileName);
+#endif
+
+#if    APL || LIN
+void handle_crash(int sig)
+#else
+void handle_crash(EXCEPTION_POINTERS *ei)
+#endif
+{
+    char sz[1024];
+
+    // Determine a name for the dump file
+    char szFileName[255];
+    const time_t now = time(nullptr);
+    struct tm tm;
+    gmtime_s(&tm, &now);
+    snprintf(szFileName, sizeof(szFileName), "Output/crash_reports/LiveTraffic_%4d-%02d-%02d_%02d-%02d-%02d.dmp",
+             tm.tm_year + 1900, tm.tm_mon+1, tm.tm_mday,
+             tm.tm_hour, tm.tm_min, tm.tm_sec);
+    
+#if APL || LIN
+	// NOTE: Laminar's post doesn't consider this safe enough for production
+	// as backtrace is NOT signal handler safe (backtrace_symbols_fd supposingly is),
+    // but in my tests it seems 'good enough' for the purpose and did write
+    // proper output at least for the most typical case of SIGSEGV.
+    // Most crashes happen in Windows anyway, so APL/LIN are less of a concern.
+    void *frames[64] = {0};
+	int frame_count = backtrace(frames, 64);
+	
+	const int fd = open(szFileName, O_CREAT | O_RDWR | O_TRUNC | O_SYNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	if(fd >= 0)
+	{
+        snprintf(sz, sizeof(sz), "File: %s\nPlatform: %s\nThread: %s\nSignal: %d\n\n",
+                 szFileName,
+#if APL
+                 "Apple",
+#else
+                 "Linux",
+#endif
+                 crash_thread_name,
+                 sig);
+        write (fd, sz, strlen(sz));
+        backtrace_symbols_fd(frames, frame_count, fd);
+		close(fd);
+	}
+	
+#endif
+#if IBM
+	// Create a mini-dump file that can be later opened up in Visual Studio or WinDbg to do post mortem debugging
+	write_mini_dump(ei, szFileName);
+#endif
+    // Last thing: we _try_ to leave a trace in X-Plane's Log.txt
+    snprintf(sz, sizeof(sz), "LiveTraffic crashed%s%s by signal %d, please upload the following dump file to the LiveTraffic Support Forum:\n",
+             *crash_thread_name ? " in thread " : "",
+             *crash_thread_name ? crash_thread_name : "",
+             sig);
+    XPLMDebugString(sz);
+    XPLMDebugString(szFileName);
+    XPLMDebugString("\n");
+}
+
+#if IBM
+#include <DbgHelp.h>
+
+typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile,
+	MINIDUMP_TYPE DumpType,
+	CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
+	CONST PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
+	CONST PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
+
+void write_mini_dump(PEXCEPTION_POINTERS exception_pointers, const char* szFileName)
+{
+	HMODULE module = ::GetModuleHandleA("dbghelp.dll");
+	if(!module)
+		module = ::LoadLibraryA("dbghelp.dll");
+
+	if(module)
+	{
+		const MINIDUMPWRITEDUMP pDump = MINIDUMPWRITEDUMP(::GetProcAddress(module, "MiniDumpWriteDump"));
+
+		if(pDump)
+		{
+			// Create dump file
+			const HANDLE handle = ::CreateFileA(szFileName, GENERIC_WRITE, FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+			if(handle != INVALID_HANDLE_VALUE)
+			{
+				MINIDUMP_EXCEPTION_INFORMATION exception_information = {};
+				exception_information.ThreadId = ::GetCurrentThreadId();
+				exception_information.ExceptionPointers = exception_pointers;
+				exception_information.ClientPointers = false;
+
+				pDump(GetCurrentProcess(), GetCurrentProcessId(), handle, MiniDumpNormal, &exception_information, nullptr, nullptr);
+				::CloseHandle(handle);
+			}
+		}
+	}
+}
+#endif
+
+//
+// MARK: Thread Handling
+//
+
+// Defines thread's name and sets the thread's locale
+ThreadSettings::ThreadSettings ([[maybe_unused]] const char* sThreadName,
+                                int localeMask,
+                                const char* sLocaleName)
+{
+    // --- Register thread with crash handler ---
+    CrashHandlerRegisterThread(sThreadName);
+    
+    // --- Set thread's name ---
+#if IBM
+    // This might not work on older Windows version, which is why we don't publish it in release builds
+#ifdef DEBUG
+    wchar_t swThreadName[100];
+    std::mbstowcs(swThreadName, sThreadName, sizeof(swThreadName));
+    SetThreadDescription(GetCurrentThread(), swThreadName);
+#endif
+    
+#elif APL
+    pthread_setname_np(sThreadName);
+#elif LIN
+    pthread_setname_np(pthread_self(),sThreadName);
+#endif
+    
+    // --- Set thread's locale ---
+    if (sLocaleName)
+    {
+#if IBM
+        _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+        setlocale(localeMask, sLocaleName);
+#else
+        threadLocale = newlocale(localeMask, sLocaleName, NULL);
+        prevLocale = uselocale(threadLocale);
+#endif
+    }
+}
+
+// Restores and cleans up locale
+ThreadSettings::~ThreadSettings()
+{
+#if IBM
+    _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
+#else
+    if (prevLocale)
+        uselocale(prevLocale);
+    if (threadLocale) {
+        freelocale(threadLocale);
+        threadLocale = locale_t(0);
+    }
+#endif
+    CrashHandlerUnregisterThread();
+}

--- a/Src/ThreadCrashHdl.cpp
+++ b/Src/ThreadCrashHdl.cpp
@@ -393,7 +393,7 @@ void handle_crash(EXCEPTION_POINTERS *ei)
 	}
 	
     // Last thing: we _try_ to leave a trace in X-Plane's Log.txt
-    snprintf(sz, sizeof(sz), "LiveTraffic crashed%s%s by signal %d, please upload the following dump file to the LiveTraffic Support Forum:\n",
+    snprintf(sz, sizeof(sz), "LiveTraffic crashed%s%s by signal %d, please upload this Log.txt and the following dump file to the LiveTraffic Support Forum:\n",
         *crash_thread_name ? " in thread " : "",
         *crash_thread_name ? crash_thread_name : "",
         sig);
@@ -403,7 +403,7 @@ void handle_crash(EXCEPTION_POINTERS *ei)
 	write_mini_dump(ei, szFileName);
 
     // Last thing: we _try_ to leave a trace in X-Plane's Log.txt
-    snprintf(sz, sizeof(sz), "LiveTraffic crashed%s%s by %s at address %p, please upload the following dump file to the LiveTraffic Support Forum:\n",
+    snprintf(sz, sizeof(sz), "LiveTraffic crashed%s%s by %s at address %p, please upload this Log.txt and the following dump file to the LiveTraffic Support Forum:\n",
         *crash_thread_name ? " in thread " : "",
         *crash_thread_name ? crash_thread_name : "",
         ExceptionCode2Txt(ei->ExceptionRecord->ExceptionCode),

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -169,6 +169,12 @@
             real world traffic, but is more likely with virtual traffic added
             to the mix.
         </li>
+        <li>Added <a href="https://github.com/TwinFan/LiveTraffic/issues/193">#193</a>
+            own crash reporter as per
+            <a href="https://developer.x-plane.com/code-sample/crash-handling/">Laminar's suggestion</a>,
+            so that if LiveTraffic causes a crash there hopefully is a
+            LiveTraffic-specific dump file in <code>Output/crash_reports</code>
+            allowing for proper analysis.</li>
     </ul>
 
     <h3>v4.1.0</h3>

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -133,6 +133,44 @@
 
     <h2>v4</h2>
 
+    <h3>v4.1.1</h3>
+    
+    <P>
+        <b>Update:</b> In case of doubt you can always just copy all files from the archive
+        over the files of your existing installation.
+    </P>
+
+    <P>At least copy the following files, which have changed compared to v4.1.0:</P>
+    <ul>
+        <li><code>lin|mac|win_x64/LiveTraffic.xpl</code></li>
+    </ul>
+    
+    <P>Change log:</P>
+    
+    <ul>
+        <li>
+            Added two options to <a href="https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-a-c-labels">Settings &gt; Aircraft Labels</a>:
+            <ul>
+                <li><i>Labels for Parked a/c</i> allows to switch off labels for parked aircraft as they can quite clutter the screen on larger airports</li>
+                <li><i>Dynamic Information &gt; Channel</i> adds the name of the channel currently driving the plane's data to the label</li>
+            </ul>
+        </li>
+        <li>Fixed checking for new versions after a change to the X-Plane.org
+            forum no longer allows providing version number information for
+            uploads.<br>
+            <strong>This means that LiveTraffic v4.1.0 and earlier cannot
+            inform you about this update to v4.1.1!</strong>
+        </li>
+        <li>Fixed processing OpenSky Masterdata File download and processing
+            after changes to both download location and format.
+        </li>
+        <li>Fixed a bug preventing parked aircraft from disappearing when a
+            taxiing aircraft comes too close. Is a very rare event when watching
+            real world traffic, but is more likely with virtual traffic added
+            to the mix.
+        </li>
+    </ul>
+
     <h3>v4.1.0</h3>
     
     <P>


### PR DESCRIPTION
- Added two options to [Settings > Aircraft Labels](https://twinfan.gitbook.io/livetraffic/setup/configuration/settings-a-c-labels):
  - _Labels for Parked a/c_ allows to switch off labels for parked aircraft as they can quite clutter the screen on larger airports
  - _Dynamic Information > Channel_ adds the name of the channel currently driving the plane's data to the label
- Fixed checking for new versions after a change to the X-Plane.org forum no longer allows providing version number information for uploads.
**This means that LiveTraffic v4.1.0 and earlier cannot inform you about this update to v4.1.1!**
- Fixed processing OpenSky Masterdata File download and processing after changes to both download location and format.
- Fixed a bug preventing parked aircraft from disappearing when a taxiing aircraft comes too close. Is a very rare event when watching real world traffic, but is more likely with virtual traffic added to the mix.
- Added #193 own crash reporter as per [Laminar's suggestion](https://developer.x-plane.com/code-sample/crash-handling/), so that if LiveTraffic causes a crash there hopefully is a LiveTraffic-specific dump file in Output/crash_reports allowing for proper analysis.

_Note:_ This merge with `master` is necessary to test the changes in the GitActions `build.yml` script. Still contains crash-testing, which must be removed before publishing.