### PR TITLE
v4.6.0 (again) OpenSky Master reworked

### DIFF
--- a/Include/DataRefs.h
+++ b/Include/DataRefs.h
@@ -1064,7 +1064,7 @@ public:
 
     bool HaveNvgrRefreshToken () const { return !sNvgrRefreshToken.empty(); }
     const std::string& GetNvgrRefreshToken () const { return sNvgrRefreshToken; }
-    void SetNvgrRefrshToken (const std::string& sNewToken);     ///< Store token and immediately save settings to disk
+    void SetNvgrRefrshToken (const std::string& sNewToken, bool bSaveImmediately = true);   ///< Store token and optionally immediately save settings to disk
     
     const std::string& GetADSBExAPIKey () const { return sADSBExAPIKey; }
     void SetADSBExAPIKey (const std::string& apiKey) { sADSBExAPIKey = apiKey; }

--- a/Include/LTADSBHub.h
+++ b/Include/LTADSBHub.h
@@ -32,6 +32,7 @@
 //MARK: ADSBHub Constants
 //
 
+#define ADSBHUB_NAME            "ADSBHub"                   ///< Human-readable Name of connection
 #define ADSBHUB_CHECK_NAME      "ADSBHub Coverage"
 #define ADSBHUB_CHECK_URL       "https://www.adsbhub.org/coverage.php"
 #define ADSBHUB_CHECK_POPUP     "Check ADSBHub's coverage"

--- a/Include/LTFlightData.h
+++ b/Include/LTFlightData.h
@@ -546,25 +546,6 @@ public:
     static void UpdateAllModels ();
     static const LTFlightData* FindFocusAc (const double bearing);
 
-    /// Prune `FF****` placeholder-hex duplicates.
-    ///
-    /// Some upstream ingest paths emit aircraft with synthetic hex
-    /// IDs of the form `FF****` when the source does not carry a real
-    /// ICAO transponder code. When a real-ICAO source (X_adsb_icao,
-    /// V_adsb_icao, V_mlat) later picks up the same aircraft and
-    /// reports its actual hex, the LiveTraffic side ends up with TWO
-    /// LTFlightData entries for the same physical aircraft — one keyed
-    /// by the FF placeholder, one by the real hex — both rendered as
-    /// separate aircraft in the sim. The duplicate at the FF key
-    /// cannot reconcile by itself because FDKeyTy is the primary key
-    /// in `mapFd` and changing it isn't supported.
-    ///
-    /// This periodic prune scans `mapFd`: any entry whose hex starts
-    /// with "FF" and whose callsign matches a non-FF entry's callsign
-    /// is invalidated (`SetInvalid`), letting the standard cleanup
-    /// pipeline remove it. Callable from the main thread only — takes
-    /// the mapFd mutex.
-    static void PrunePlaceholderHexDuplicates ();
 #ifdef DEBUG
     static void RemoveAllAcButSelected ();
 #endif

--- a/Include/LTOpenSky.h
+++ b/Include/LTOpenSky.h
@@ -111,19 +111,6 @@ protected:
 constexpr std::chrono::duration OPSKY_WAIT_BETWEEN = std::chrono::milliseconds( 300);   ///< Wait between immediate requests to OpenSky Master
 constexpr std::chrono::duration OPSKY_WAIT_NOQUEUE = std::chrono::milliseconds(3000);   ///< Wait if there is no request in the queue
 #define OPSKY_MD_NAME           "OpenSky Masterdata Online"
-#define OPSKY_MD_URL            "https://opensky-network.org/api/metadata/aircraft/icao/"
-#define OPSKY_MD_TRANSP_ICAO    "icao24"
-#define OPSKY_MD_COUNTRY        "country"
-#define OPSKY_MD_MAN            "manufacturerName"
-#define OPSKY_MD_MDL            "model"
-#define OPSKY_MD_OP_ICAO        "operatorIcao"
-#define OPSKY_MD_OP             "owner"
-#define OPSKY_MD_REG            "registration"
-#define OPSKY_MD_AC_TYPE_ICAO   "typecode"
-#define OPSKY_MD_CAT_DESCR      "categoryDescription"
-#define OPSKY_MD_TEXT_VEHICLE   "Surface Vehicle"
-constexpr size_t OPSKY_MD_TEXT_VEHICLE_LEN = 20;    ///< length after which category description might contain useful text in case of a Surface Vehicle
-#define OPSKY_MD_TEXT_NO_CAT    "No ADS-B Emitter Category Information"
 
 #define OPSKY_ROUTE_URL         "https://opensky-network.org/api/routes?callsign="
 #define OPSKY_ROUTE_CALLSIGN    "callsign"
@@ -146,7 +133,6 @@ public:
 protected:
     bool AcceptRequest (const acStatUpdateTy& requ) override;       ///< accept requests that aren't in the ignore lists
     void Main () override;                                          ///< virtual thread main function
-    bool ProcessMasterData (JSON_Object* pJAc);                     ///< Process received aircraft master data
     bool ProcessRouteInfo (JSON_Object* pJRoute);                   ///< Process received route info
 };
 

--- a/Include/LTOpenSky.h
+++ b/Include/LTOpenSky.h
@@ -110,7 +110,7 @@ protected:
 
 constexpr std::chrono::duration OPSKY_WAIT_BETWEEN = std::chrono::milliseconds( 300);   ///< Wait between immediate requests to OpenSky Master
 constexpr std::chrono::duration OPSKY_WAIT_NOQUEUE = std::chrono::milliseconds(3000);   ///< Wait if there is no request in the queue
-#define OPSKY_MD_NAME           "OpenSky Masterdata Online"
+#define OPSKY_MD_NAME           "OpenSky Route Info"
 
 #define OPSKY_ROUTE_URL         "https://opensky-network.org/api/routes?callsign="
 #define OPSKY_ROUTE_CALLSIGN    "callsign"
@@ -140,7 +140,7 @@ protected:
 //MARK: OpenSkyAcMasterFile
 //
 
-#define OPSKY_MDF_NAME          "OpenSky Masterdata File"
+#define OPSKY_MDF_NAME          "OpenSky Aircraft DB File"
 #define OPSKY_MDF_URL           "https://s3.opensky-network.org/data-samples/metadata/"
 #define OPSKY_MDF_FILE_BEGIN    "aircraft-database-complete-"
 #define OPSKY_MDF_FILE          "aircraft-database-complete-%04d-%02d.csv"

--- a/Include/LTRealTraffic.h
+++ b/Include/LTRealTraffic.h
@@ -482,6 +482,10 @@ protected:
     bool ProcessRecvedWeatherData (const char* weather);                                      ///< Process UDP weather JSON from RT Application
     std::string GetSlug (unsigned long hex) const;          ///< returns a slug string for a given hex id
     
+    /// For placeholder planes with an "FF" hex id check for duplicates based on call sign
+    bool IsPlacehoderAndDuplicate (const LTFlightData::FDKeyTy& fdKey,
+                                   const std::string& call) const;
+    
     /// Determine timestamp adjustment necessary in case of historic data
     void AdjustTimestamp (double& ts, int nBuffer);
     /// Return a string describing the current timestamp adjustment

--- a/Include/LTRealTraffic.h
+++ b/Include/LTRealTraffic.h
@@ -430,6 +430,8 @@ protected:
     // MARK: Direct Connection by Request/Reply
 protected:
     void MainDirect ();                                     ///< thread main function for the direct connection
+    bool InitCurl () override;                              ///< sets CURLOPT_FORBID_REUSE
+
     /// Which request do we need next and when can we send it?
     std::chrono::time_point<std::chrono::steady_clock> SetRequType (const positionTy& pos);
 public:

--- a/LiveTraffic.xcodeproj/project.xcworkspace/xcuserdata/birger.xcuserdatad/xcdebugger/Expressions.xcexplist
+++ b/LiveTraffic.xcodeproj/project.xcworkspace/xcuserdata/birger.xcuserdatad/xcdebugger/Expressions.xcexplist
@@ -81,13 +81,13 @@
          contextName = "Apt::FindEdgesForHeading(double, double, std::__1::vector&lt;unsigned long, std::__1::allocator&lt;unsigned long&gt; &gt;&amp;, TaxiEdge::edgeTy) const:LTApt.cpp">
          <PersistentStrings>
             <PersistentString
-               value = "vecTaxiEdges[222]">
+               value = "lst[1385]">
             </PersistentString>
             <PersistentString
                value = "vecTaxiEdgesIdxHead[3321]">
             </PersistentString>
             <PersistentString
-               value = "lst[1385]">
+               value = "vecTaxiEdges[222]">
             </PersistentString>
          </PersistentStrings>
       </ContextState>
@@ -142,10 +142,10 @@
          contextName = "LTFlightData::AddDynData(LTFlightData::FDDynamicData const&amp;, int, int, positionTy*):LTFlightData.cpp">
          <PersistentStrings>
             <PersistentString
-               value = "posDeque">
+               value = "dynDataDeque">
             </PersistentString>
             <PersistentString
-               value = "dynDataDeque">
+               value = "posDeque">
             </PersistentString>
             <PersistentString
                value = "currCycle">
@@ -284,10 +284,10 @@
                value = "cull">
             </PersistentString>
             <PersistentString
-               value = "iter-&gt;second">
+               value = "tcas">
             </PersistentString>
             <PersistentString
-               value = "tcas">
+               value = "iter-&gt;second">
             </PersistentString>
          </PersistentStrings>
       </ContextState>
@@ -492,7 +492,7 @@
          contextName = "LTAircraft::CalcPPos():LTAircraft.cpp">
          <PersistentStrings>
             <PersistentString
-               value = "from">
+               value = "turn">
             </PersistentString>
             <PersistentString
                value = "to">
@@ -504,7 +504,7 @@
                value = "ppos">
             </PersistentString>
             <PersistentString
-               value = "turn">
+               value = "from">
             </PersistentString>
          </PersistentStrings>
       </ContextState>
@@ -602,10 +602,10 @@
                value = "mapFd">
             </PersistentString>
             <PersistentString
-               value = "sizeof(bool)">
+               value = "dataRefs">
             </PersistentString>
             <PersistentString
-               value = "dataRefs">
+               value = "sizeof(bool)">
             </PersistentString>
             <PersistentString
                value = "(int*)p">
@@ -1215,10 +1215,10 @@
                value = "_startTime">
             </PersistentString>
             <PersistentString
-               value = "_targetTime">
+               value = "_deltaDist">
             </PersistentString>
             <PersistentString
-               value = "_deltaDist">
+               value = "_targetTime">
             </PersistentString>
          </PersistentStrings>
       </ContextState>

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -796,6 +796,7 @@ ILWrect (0, 400, 965, 0)
     bChannel[DR_CHANNEL_ADSB_FI_ONLINE          - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_OPEN_SKY_ONLINE         - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERDATA  - DR_CHANNEL_FIRST] = true;
+    bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERFILE  - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_OPEN_GLIDER_NET         - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_SYNTHETIC               - DR_CHANNEL_FIRST] = true;
 
@@ -2122,7 +2123,7 @@ bool DataRefs::LoadConfigFile()
 
     // which conversion to do with the (older) version of the config file?
     unsigned long cfgFileVer = 0;
-    enum cfgFileConvE { CFG_NO_CONV=0, CFG_V3, CFG_V31, CFG_V331, CFG_V342, CFG_V350, CFG_V420, CFG_V436 } conv = CFG_NO_CONV;
+    enum cfgFileConvE { CFG_NO_CONV=0, CFG_V3, CFG_V31, CFG_V331, CFG_V342, CFG_V350, CFG_V420, CFG_V460 } conv = CFG_NO_CONV;
     
     // open a config file
     std::string sFileName (LTCalcFullPath(PATH_CONFIG_FILE));
@@ -2182,8 +2183,8 @@ bool DataRefs::LoadConfigFile()
                 cfgFileVer += std::stoul(m[3]);
             
             // any conversions required?
-            if (cfgFileVer < 40306)         // < 4.3.6: Switch off OpenSky Master File
-                conv = CFG_V436;
+            if (cfgFileVer < 40600)         // < 4.6.0: Switch on OpenSky Master File again (was switched off in v4.3.6, but now the online service stopped working)
+                conv = CFG_V460;
             if (cfgFileVer < 40200)         // < 4.2.0: Clear ADSBEx API key (switch to other service)
                 conv = CFG_V420;
             if (cfgFileVer < 30500) {       // < 3.5.0
@@ -2273,10 +2274,10 @@ bool DataRefs::LoadConfigFile()
                         if (*i == DATA_REFS_LT[DR_CHANNEL_ADSB_EXCHANGE_ONLINE])
                             sVal = "0";
                         [[fallthrough]];
-                    case CFG_V436:
-                        // Switching off OpenSky Master File
+                    case CFG_V460:
+                        // Switching on OpenSky Master File (was switched of with v4.3.6)
                         if (*i == DATA_REFS_LT[DR_CHANNEL_OPEN_SKY_AC_MASTERFILE])
-                            sVal = "0";
+                            sVal = "1";
                         break;
                 }
                 
@@ -2580,6 +2581,7 @@ void DataRefs::SetChannelEnabled (dataRefsLT ch, bool bEnable)
     // If OpenSky Tracking is enabled then make sure OpenSky Master is also
     if (IsChannelEnabled(DR_CHANNEL_OPEN_SKY_ONLINE)) {
         bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERDATA - DR_CHANNEL_FIRST] = true;
+        bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERFILE - DR_CHANNEL_FIRST] = true;
     }
 
     // When the user enables a channel we also reset its validity flag.

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -795,7 +795,6 @@ ILWrect (0, 400, 965, 0)
     bChannel[DR_CHANNEL_AIRPLANES_LIVE          - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_ADSB_FI_ONLINE          - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_OPEN_SKY_ONLINE         - DR_CHANNEL_FIRST] = true;
-    bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERDATA  - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERFILE  - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_OPEN_GLIDER_NET         - DR_CHANNEL_FIRST] = true;
     bChannel[DR_CHANNEL_SYNTHETIC               - DR_CHANNEL_FIRST] = true;
@@ -2278,6 +2277,9 @@ bool DataRefs::LoadConfigFile()
                         // Switching on OpenSky Master File (was switched of with v4.3.6)
                         if (*i == DATA_REFS_LT[DR_CHANNEL_OPEN_SKY_AC_MASTERFILE])
                             sVal = "1";
+                        // Switching off OpenSky Master Data
+                        if (*i == DATA_REFS_LT[DR_CHANNEL_OPEN_SKY_AC_MASTERDATA])
+                            sVal = "0";
                         break;
                 }
                 
@@ -2578,9 +2580,8 @@ void DataRefs::SetChannelEnabled (dataRefsLT ch, bool bEnable)
 {
     bChannel[ch - DR_CHANNEL_FIRST] = bEnable;
 
-    // If OpenSky Tracking is enabled then make sure OpenSky Master is also
+    // If OpenSky Tracking is enabled then make sure OpenSky Master File is also
     if (IsChannelEnabled(DR_CHANNEL_OPEN_SKY_ONLINE)) {
-        bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERDATA - DR_CHANNEL_FIRST] = true;
         bChannel[DR_CHANNEL_OPEN_SKY_AC_MASTERFILE - DR_CHANNEL_FIRST] = true;
     }
 

--- a/Src/DataRefs.cpp
+++ b/Src/DataRefs.cpp
@@ -2309,7 +2309,7 @@ bool DataRefs::LoadConfigFile()
             else if (sDataRef == CFG_OPENSKY_SECRET)
                 SetOpenSkySecret(Cleartext(sVal));
             else if (sDataRef == CFG_NVGR_REFRESH_TOKEN)
-                SetNvgrRefrshToken(Cleartext(sVal));
+                SetNvgrRefrshToken(Cleartext(sVal), false);
             else if (sDataRef == CFG_ADSBEX_API_KEY) {
                 // With v4.2 ADSBEx switches to a new service, so we need a new API key
                 if (conv != CFG_V420)
@@ -2631,10 +2631,12 @@ int DataRefs::CntChannelEnabled () const
 
 
 // Store token and immediately save settings to disk
-void DataRefs::SetNvgrRefrshToken (const std::string& sNewToken)
+void DataRefs::SetNvgrRefrshToken (const std::string& sNewToken,
+                                   bool bSaveImmediately)
 {
     sNvgrRefreshToken = sNewToken;
-    SaveConfigFile();
+    if (bSaveImmediately)
+        SaveConfigFile();
 }
 
 

--- a/Src/LTADSBHub.cpp
+++ b/Src/LTADSBHub.cpp
@@ -35,7 +35,6 @@
 // MARK: ADSBHub Definitions
 //
 
-#define ADSBHUB_NAME                "ADSBHub"               ///< Human-readable Name of connection
 #define ADSBHUB_HOST                "data.adsbhub.org"      ///< Host to connect to
 constexpr int ADSBHUB_PORT          = 5002;                 ///< Port to connect to
 constexpr size_t ADSBHUB_BUF_SIZE   = 8192;                 ///< Buffer size to use

--- a/Src/LTChannel.cpp
+++ b/Src/LTChannel.cpp
@@ -637,7 +637,6 @@ bool LTOnlineChannel::InitCurl ()
     curl_easy_setopt(pCurl, CURLOPT_TCP_KEEPALIVE, 1L);
     curl_easy_setopt(pCurl, CURLOPT_TCP_KEEPIDLE,  20L);
     curl_easy_setopt(pCurl, CURLOPT_TCP_KEEPINTVL, 10L);
-    curl_easy_setopt(pCurl, CURLOPT_FORBID_REUSE,  1L);
 
     // success
     return true;

--- a/Src/LTFlightData.cpp
+++ b/Src/LTFlightData.cpp
@@ -1522,27 +1522,6 @@ void LTFlightData::CalcNextPosMain ()
                 }
             }
         }
-            
-        // Periodic prune of `FF****` placeholder-hex duplicates.
-        //
-        // Some upstream ingest paths emit aircraft with synthetic
-        // `FF****` hex IDs when the source does not carry a real ICAO
-        // code. When a real-ICAO source later picks up the same callsign,
-        // we end up with two LTFlightData entries (one per hex) and two
-        // rendered aircraft. The prune walks mapFd and invalidates any
-        // FF-hex entry whose callsign matches a non-FF entry. Throttled
-        // to once every 10 s because the scan locks mapFd, and the
-        // duplicate condition develops over many seconds (placeholder
-        // appears, real-hex picks up 5-60 s later) — running per-flight-
-        // loop would be wasteful.
-        {
-            static std::chrono::steady_clock::time_point lastPrune;
-            const auto now = std::chrono::steady_clock::now();
-            if (now - lastPrune >= std::chrono::seconds(10)) {
-                lastPrune = now;
-                LTFlightData::PrunePlaceholderHexDuplicates();
-            }
-        }
         
         // sleep till woken up for processing or stopping
         {
@@ -4096,71 +4075,6 @@ void LTFlightData::UpdateAllModels ()
     }
 }
 
-// Prune `FF****` placeholder-hex duplicates.
-//
-// See header doc for full rationale. Two-pass design:
-//   pass 1 — collect callsigns held by non-FF (real-hex) entries
-//   pass 2 — invalidate any FF entry whose callsign is in the set
-//
-// Two passes are necessary because we cannot decide-and-invalidate in
-// a single sweep: a real-hex entry may be discovered AFTER its FF
-// counterpart in map iteration order, and we would miss the prune.
-//
-// Performance: O(N) for N entries in mapFd, run from the main thread.
-// The scan walks raw `mapFd` keys and uses `GetUnsafeStat()` to read
-// callsigns without per-entry mutex acquisition — racy but acceptable:
-// the worst case is a stale callsign read that we re-evaluate on the
-// next call (this method is intended to be invoked periodically, not
-// once-per-frame).
-void LTFlightData::PrunePlaceholderHexDuplicates ()
-{
-    try {
-        // Hold the map mutex for the whole pass: we both read and
-        // potentially SetInvalid entries within it, and any concurrent
-        // erase from the cleanup pipeline must not race with our
-        // iteration.
-        std::lock_guard<std::mutex> lock (mapFdMutex);
-
-        // Lambda: does the hex key start with "FF" (case-insensitive)?
-        // FDKeyTy::key is the canonical uppercase hex string per
-        // SetKey()'s normalization, but we tolerate either case here
-        // for robustness.
-        auto isPlaceholderHex = [](const std::string& hex) -> bool {
-            return hex.length() >= 2 &&
-                   (hex[0] == 'F' || hex[0] == 'f') &&
-                   (hex[1] == 'F' || hex[1] == 'f');
-        };
-
-        // Pass 1: collect callsigns from real-hex (non-FF) entries.
-        // Skip entries with empty callsigns — they cannot be matched.
-        std::set<std::string> realHexCallsigns;
-        for (const auto& fdPair : mapFd) {
-            if (isPlaceholderHex(fdPair.first.key))
-                continue;
-            const std::string& call = fdPair.second.GetUnsafeStat().call;
-            if (!call.empty())
-                realHexCallsigns.insert(call);
-        }
-
-        // Pass 2: invalidate FF entries whose callsign is held by a
-        // real-hex entry. SetInvalid(true) also drops the rendered
-        // aircraft so the visual duplicate disappears immediately.
-        for (auto& fdPair : mapFd) {
-            if (!isPlaceholderHex(fdPair.first.key))
-                continue;
-            const std::string& call = fdPair.second.GetUnsafeStat().call;
-            if (!call.empty() && realHexCallsigns.count(call) > 0) {
-                LOG_MSG(logINFO,
-                        "PRUNE_FF: removing placeholder-hex %s (cs=%s)"
-                        " — real-hex entry exists for same callsign",
-                        fdPair.first.key.c_str(), call.c_str());
-                fdPair.second.SetInvalid();
-            }
-        }
-    } catch(const std::system_error& e) {
-        LOG_MSG(logERR, ERR_LOCK_ERROR, "mapFd", e.what());
-    }
-}
 
 // finds the closest a/c roughly in the given direction ('focus a/c')
 const LTFlightData* LTFlightData::FindFocusAc (const double bearing)

--- a/Src/LTMain.cpp
+++ b/Src/LTMain.cpp
@@ -431,6 +431,70 @@ void URLGet (const std::string& inUrl,
                 inUrl.c_str(), (int)outHttpRes);
 }
 
+/// Quick info structure for file downloads
+struct FileDownloadInfo {
+    const std::string& url;
+    const std::string& path;
+    curl_off_t fileSize = 0;            // set by progress callback
+    curl_off_t downloaded = 0;          // set by progress callback
+    std::time_t tLastByteRcved = 0;     // initialized to 'now', then used by progress callback: when received the last bytes?
+    
+    FileDownloadInfo (const std::string& _url, const std::string& _path) :
+    url(_url), path(_path), tLastByteRcved(std::time(nullptr)) {}
+};
+
+/// @brief Progress callback, called by CURL while downloading a file
+/// @see https://curl.se/libcurl/c/CURLOPT_XFERINFOFUNCTION.html
+static int RemoteFileProgressCallback(void *clientp,
+                                      curl_off_t dltotal,
+                                      curl_off_t dlnow,
+                                      curl_off_t /*ultotal*/,
+                                      curl_off_t /*ulnow*/)
+{
+    FileDownloadInfo &fdlInfo = *((FileDownloadInfo*)clientp);
+    int ret = CURL_PROGRESSFUNC_CONTINUE;
+    
+    // Just received the first bytes?
+    if (!fdlInfo.downloaded && dlnow > 0) {
+        LOG_MSG(logDEBUG, "Received first %zd bytes of %s", dlnow, fdlInfo.url.c_str());
+    }
+    
+    // Mark every 10% of download
+    if (dltotal > 0) {
+        const curl_off_t pctOld = fdlInfo.fileSize > 0 ? (fdlInfo.downloaded * 10 / fdlInfo.fileSize) : 0;
+        const curl_off_t pctNew = dlnow * 10 / dltotal;
+        if (pctNew > pctOld) {
+            LOG_MSG(logDEBUG, "Received %ld%% of %s",
+                    dlnow * 100 / dltotal, fdlInfo.url.c_str());
+        }
+    }
+    // or every 1MB
+    else {
+        const curl_off_t mbOld = fdlInfo.fileSize / (1024L * 1024L);
+        const curl_off_t mbNew = dlnow / (1024L * 1024L);
+        if (mbOld > mbNew) {
+            LOG_MSG(logDEBUG, "Received %ld MB of %s", mbNew, fdlInfo.url.c_str());
+        }
+    }
+    
+    // Did we actually receive _anything_? -> remember wall clock time for timeout calculation
+    const std::time_t now = std::time(nullptr);
+    const std::time_t dt = now - fdlInfo.tLastByteRcved;
+    if (dlnow > fdlInfo.downloaded)                 // received some bytes
+        fdlInfo.tLastByteRcved = now;
+    else if (dt > 60) {                             // Not received anything for 60s? -> abort
+        LOG_MSG(logERR, "Aborting download after receiving no data for 60s: %s", fdlInfo.url.c_str());
+        ret = 1;                                    // indicates "abort the transfer"
+    }
+    
+    // store latest values
+    fdlInfo.fileSize = dltotal;
+    fdlInfo.downloaded = dlnow;
+    
+    return ret;
+}
+
+
 // Download the given file, `false` if HTTP 404 not found, exceptions otherwise
 bool RemoteFileDownload (const std::string& url, const std::string& path)
 {
@@ -448,12 +512,18 @@ bool RemoteFileDownload (const std::string& url, const std::string& path)
     
     // prepare the handle with the right options
     curl_easy_setopt(pCurl.get(), CURLOPT_NOSIGNAL, 1);
-    curl_easy_setopt(pCurl.get(), CURLOPT_TIMEOUT, 3 * dataRefs.GetNetwTimeoutMax());
     curl_easy_setopt(pCurl.get(), CURLOPT_ERRORBUFFER, curl_errtxt);
     curl_easy_setopt(pCurl.get(), CURLOPT_WRITEFUNCTION, NULL);     // use CURL's standard of writing to FILE
     curl_easy_setopt(pCurl.get(), CURLOPT_WRITEDATA, fOut);
     curl_easy_setopt(pCurl.get(), CURLOPT_USERAGENT, HTTP_USER_AGENT);
     curl_easy_setopt(pCurl.get(), CURLOPT_URL, url.c_str());
+    
+    // Progress control
+    curl_easy_setopt(pCurl.get(), CURLOPT_TIMEOUT, 0);              // don't time out, we handle that ourselves
+    curl_easy_setopt(pCurl.get(), CURLOPT_NOPROGRESS, 0);           // use our own progress tracking
+    curl_easy_setopt(pCurl.get(), CURLOPT_XFERINFOFUNCTION, RemoteFileProgressCallback);
+    FileDownloadInfo fdlInfo (url, path);
+    curl_easy_setopt(pCurl.get(), CURLOPT_XFERINFODATA, &fdlInfo);
 
     // perform the HTTP get request
     CURLcode cc = curl_easy_perform(pCurl.get());

--- a/Src/LTNavigraph.cpp
+++ b/Src/LTNavigraph.cpp
@@ -356,7 +356,7 @@ bool NvgrFR24Connection::ProcessFetchedData ()
                          pszChName, errMsg.c_str());
                 SetValid(false,false);
                 SetEnable(false);
-                dataRefs.SetNvgrRefrshToken("");
+                dataRefs.SetNvgrRefrshToken("", false);
                 AuthInit();
                 return false;
             }
@@ -832,11 +832,11 @@ void NvgrFR24Connection::AuthMain ()
                 // HTTP_BAD_REQUEST -> handle the expected stuff, throw the unexpected
                 if (httpResp == HTTP_BAD_REQUEST) {
                     std::string sError = jog_s(pObj, NVGR_ERROR);
-                    if (sError.empty()) sError = jog_s(pObj, NVGR_ERROR_MSG);       // unlikely...but better safe than sorry: we also try 'message' if 'error' was empty; at least good for final error reporting
+                    if (sError.empty()) sError = jog_s(pObj, NVGR_ERROR_MSG);   // unlikely...but better safe than sorry: we also try 'message' if 'error' was empty; at least good for final error reporting
                     if (sError == "authorization_pending") { /* do nothing...just keep polling */ }
                     else if (sError == "slow_down") { tInterval += NVGR_AUTH_INTERVAL_DEFAULT; }
                     else if (sError == "access_denied") {
-                        dataRefs.SetNvgrRefrshToken("");            // clear any potentially saved refresh token
+                        dataRefs.SetNvgrRefrshToken("", false);                 // clear any potentially saved refresh token
                         AuthSetState (NVGR_AUTH_WAITING, NVGR_AUTH_ERROR);
                         sErrMsg = "Access has been denied.";
                     }

--- a/Src/LTOpenSky.cpp
+++ b/Src/LTOpenSky.cpp
@@ -1024,8 +1024,8 @@ bool OpenSkyAcMasterFile::OpenDatabaseFile ()
     tm.tm_year += 1900;
     tm.tm_mon++;
     
-    // Try this month and two previous months
-    for (int i = 2; i >= 0; --i) {
+    // Try this month and the previous months
+    for (int i = 1; i >= 0; --i) {
         if (TryOpenDbFile(tm.tm_year, tm.tm_mon))
             return true;
         // try previous month, potentially rolling back to previous year
@@ -1035,8 +1035,13 @@ bool OpenSkyAcMasterFile::OpenDatabaseFile ()
         }
     }
     
-    // as a last resort: we _know_ that the file for FEB-2025 was there
-    return TryOpenDbFile(2025, 2);
+    // as a last resort: we _know_ that the file for AUG-2025 was there
+    if (!TryOpenDbFile(2025, 8)) {
+        LOG_MSG(logERR, "%s: Could not download/open any aircraft database file, which may affect aircraft type derivation, hence proper representation of planes.",
+                ChName());
+        return false;
+    }
+    return true;
 }
 
 
@@ -1067,7 +1072,7 @@ bool OpenSkyAcMasterFile::TryOpenDbFile (int year, int month)
             url += sAcDbfileName;
             LOG_MSG(logDEBUG, "Trying to download %s", url.c_str());
             if (!RemoteFileDownload(url,filePath)) {
-                LOG_MSG(logWARN, "Download of %s unavailable", url.c_str());
+                LOG_MSG(logINFO, "Download of %s unavailable", url.c_str());
                 return false;
             }
 
@@ -1180,7 +1185,7 @@ bool OpenSkyAcMasterFile::TryOpenDbFile (int year, int month)
         return true;
         
     } catch (const std::exception& e) {
-        LOG_MSG(logERR, "Could not download/open a/c database file '%s': %s", sAcDbfileName, e.what());
+        LOG_MSG(logINFO, "Could not download/open a/c database file '%s': %s", sAcDbfileName, e.what());
     } catch (...) {
         LOG_MSG(logERR, "Could not download/open a/c database file '%s'", sAcDbfileName);
     }

--- a/Src/LTOpenSky.cpp
+++ b/Src/LTOpenSky.cpp
@@ -549,8 +549,7 @@ LTACMasterdataChannel(DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, OPSKY_MD_NAME)
 // accept requests that aren't in the ignore lists
 bool OpenSkyAcMasterdata::AcceptRequest (const acStatUpdateTy& r)
 {
-    if ((r.type == DATREQU_ROUTE ||                     // accepting all kinds of call signs
-         r.acKey.eKeyType == LTFlightData::KEY_ICAO) && // but only ICAO-typed master data requests
+    if (r.type == DATREQU_ROUTE &&                     // accepting all kinds of route requests only
         !ShallIgnore(r))
     {
         InsertRequest(r);
@@ -620,10 +619,9 @@ void OpenSkyAcMasterdata::Main ()
 std::string OpenSkyAcMasterdata::GetURL (const positionTy& /*pos*/)
 {
     switch (currRequ.type) {
-        case DATREQU_AC_MASTER:
-            return std::string(OPSKY_MD_URL) + URLEncode(currRequ.acKey.key);
         case DATREQU_ROUTE:
             return std::string(OPSKY_ROUTE_URL) + URLEncode(currRequ.callSign);
+        case DATREQU_AC_MASTER:
         case DATREQU_NONE:
             return std::string();
     }
@@ -652,67 +650,15 @@ bool OpenSkyAcMasterdata::ProcessFetchedData ()
     
     // Pass on the further processing depending on the request type
     switch (currRequ.type) {
-        case DATREQU_AC_MASTER:
-            return ProcessMasterData(pObj);
         case DATREQU_ROUTE:
             return ProcessRouteInfo(pObj);
+        case DATREQU_AC_MASTER:                 // can't process master data any longer
         case DATREQU_NONE:
             break;
     }
     return false;
 }
 
-
-// Process received aircraft master data
-bool OpenSkyAcMasterdata::ProcessMasterData (JSON_Object* pJAc)
-{
-    LTFlightData::FDKeyTy fdKey;        // the key: transponder Icao code, filled from response!
-    LTFlightData::FDStaticData statDat; // here we collect the master data
-
-    // fetch values from the online data
-    fdKey.SetKey(LTFlightData::KEY_ICAO,
-                 jog_s(pJAc, OPSKY_MD_TRANSP_ICAO));
-    statDat.reg         = jog_s(pJAc, OPSKY_MD_REG);
-    statDat.country     = jog_s(pJAc, OPSKY_MD_COUNTRY);
-    statDat.acTypeIcao  = jog_s(pJAc, OPSKY_MD_AC_TYPE_ICAO);
-    statDat.man         = jog_s(pJAc, OPSKY_MD_MAN);
-    statDat.mdl         = jog_s(pJAc, OPSKY_MD_MDL);
-    statDat.catDescr    = jog_s(pJAc, OPSKY_MD_CAT_DESCR);
-    statDat.op          = jog_s(pJAc, OPSKY_MD_OP);
-    statDat.opIcao      = jog_s(pJAc, OPSKY_MD_OP_ICAO);
-            
-    // -- Ground vehicle identification --
-    // OpenSky only delivers "category description" and has a
-    // pretty clear indicator for a ground vehicle
-    if (statDat.acTypeIcao.empty() &&           // don't know a/c type yet
-        (statDat.catDescr.find(OPSKY_MD_TEXT_VEHICLE) != std::string::npos ||
-         // I'm having the feeling that if nearly all is empty and the category description is "No Info" then it's often also a ground vehicle
-         (statDat.catDescr.find(OPSKY_MD_TEXT_NO_CAT) != std::string::npos &&
-          statDat.man.empty() &&
-          statDat.mdl.empty() &&
-          statDat.opIcao.empty())))
-    {
-        // we assume ground vehicle
-        statDat.acTypeIcao = dataRefs.GetDefaultCarIcaoType();
-        // The category description usually is something like
-        // "Surface Vehicle – Service Vehicle"
-        // Save the latter part if we have no model info yet
-        if (statDat.mdl.empty() &&
-            statDat.catDescr.find(OPSKY_MD_TEXT_VEHICLE) != std::string::npos &&
-            statDat.catDescr.length() > OPSKY_MD_TEXT_VEHICLE_LEN)
-        {
-            statDat.mdl = statDat.catDescr.c_str() + OPSKY_MD_TEXT_VEHICLE_LEN;
-        }
-    }
-    // Replace type GRND with our default car type, too
-    else if (statDat.acTypeIcao == "GRND" || statDat.acTypeIcao == "GND")
-        statDat.acTypeIcao = dataRefs.GetDefaultCarIcaoType();
-    
-    // Perform the update
-    UpdateStaticData(fdKey, statDat);
-    return true;
-}
-        
 
 // Process received route info
 bool OpenSkyAcMasterdata::ProcessRouteInfo (JSON_Object* pJRoute)

--- a/Src/LTRealTraffic.cpp
+++ b/Src/LTRealTraffic.cpp
@@ -282,6 +282,18 @@ void RealTrafficConnection::MainDirect ()
         WeatherReset();
 }
 
+
+bool RealTrafficConnection::InitCurl ()
+{
+    if (LTFlightDataChannel::InitCurl()) {
+        // Balt preferred this option for RealTraffic, which I don't want for all the other channels
+        curl_easy_setopt(pCurl, CURLOPT_FORBID_REUSE,  1L);
+        return true;
+    }
+    return false;
+}
+
+
 // Which request do we need next and when?
 std::chrono::time_point<std::chrono::steady_clock> RealTrafficConnection::SetRequType (const positionTy& _pos)
 {

--- a/Src/LTRealTraffic.cpp
+++ b/Src/LTRealTraffic.cpp
@@ -807,6 +807,10 @@ bool RealTrafficConnection::ProcessTrafficBuffer (const JSON_Object* pBuf)
         stat.catDescr           = GetADSBEmitterCat(s);
         stat.slug               = GetSlug(fdKey.num);
         
+        // Skip placeholder aircraft, for which proper data is available
+        if (IsPlacehoderAndDuplicate(fdKey, stat.call))
+            continue;
+        
         // RealTraffic often sends ASW20 when it should be AS20, a glider
         if (stat.acTypeIcao == "ASW20") stat.acTypeIcao = "AS20";
         
@@ -1137,6 +1141,10 @@ bool RealTrafficConnection::ProcessParkedAcBuffer (const JSON_Object* pData)
         stat.call               = std::move(dat.call);
         stat.reg                = std::move(dat.reg);
 
+        // Skip placeholder aircraft, for which proper data is available
+        if (IsPlacehoderAndDuplicate(fdKey, stat.call))
+            continue;
+        
         // RealTraffic often sends ASW20 when it should be AS20, a glider
         if (stat.acTypeIcao == "ASW20") stat.acTypeIcao = "AS20";
         
@@ -2305,6 +2313,13 @@ bool RealTrafficConnection::ProcessRTTFC (LTFlightData::FDKeyTy& fdKey,
         const std::string& sCat = tfc[RT_RTTFC_CATEGORY];
         stat.catDescr       = GetADSBEmitterCat(sCat);
         
+        // Skip placeholder aircraft silently, for which proper data is available
+        if (IsPlacehoderAndDuplicate(fdKey, stat.call))
+            return true;
+        
+        // RealTraffic often sends ASW20 when it should be AS20, a glider
+        if (stat.acTypeIcao == "ASW20") stat.acTypeIcao = "AS20";
+
         // Static objects are all equally marked with a/c type TWR
         if ((sCat == "C3" || sCat == "C4" || sCat == "C5") ||
             (stat.reg == STATIC_OBJECT_TYPE && stat.acTypeIcao == STATIC_OBJECT_TYPE))
@@ -2494,6 +2509,13 @@ bool RealTrafficConnection::ProcessAITFC (LTFlightData::FDKeyTy& fdKey,
         
         stat.slug               = GetSlug(fdKey.num);
 
+        // Skip placeholder aircraft silently, for which proper data is available
+        if (IsPlacehoderAndDuplicate(fdKey, stat.call))
+            return true;
+        
+        // RealTraffic often sends ASW20 when it should be AS20, a glider
+        if (stat.acTypeIcao == "ASW20") stat.acTypeIcao = "AS20";
+        
         // -- dynamic data --
         LTFlightData::FDDynamicData dyn;
         
@@ -2572,6 +2594,49 @@ std::string RealTrafficConnection::GetSlug (unsigned long hex) const
 }
 
 
+/// For placeholder planes with an "FF" hex id check for duplicates based on call sign
+bool RealTrafficConnection::IsPlacehoderAndDuplicate (const LTFlightData::FDKeyTy& fdKey,
+                                                      const std::string& _call) const
+{
+    // Lambda: does the hex key start with "FF" (case-insensitive)?
+    // FDKeyTy::key is the canonical uppercase hex string per
+    // SetKey()'s normalization, but we tolerate either case here
+    // for robustness.
+    auto isPlaceholderHex = [](const std::string& hex) -> bool {
+        return hex.length() == 6 &&
+        (hex[0] == 'F' || hex[0] == 'f') &&
+        (hex[1] == 'F' || hex[1] == 'f');
+    };
+    
+    // Is this a placeholder plane at all?
+    if (!isPlaceholderHex(fdKey.key) ||
+        _call.empty())                      // or doesn't have a call sign to match
+        return false;
+    
+    // Prepare the call sign...it often has a trailing underscope, which hampers later comparison
+    std::string call = _call;
+    if (call.back() == '_') call.pop_back();
+    
+    try {
+        // Hold the map mutex for the whole pass: we both read and
+        // potentially SetInvalid entries within it, and any concurrent
+        // erase from the cleanup pipeline must not race with our
+        // iteration.
+        std::lock_guard<std::mutex> lock (mapFdMutex);
+        
+        // Pass 1: collect callsigns from real-hex (non-FF) entries.
+        // Skip entries with empty callsigns — they cannot be matched.
+        for (const auto& fdPair : mapFd) {
+            if (isPlaceholderHex(fdPair.first.key))
+                continue;
+            if (fdPair.second.GetUnsafeStat().call == call)
+                return true;
+        }
+    } catch(const std::system_error& e) {
+        LOG_MSG(logERR, ERR_LOCK_ERROR, "mapFd", e.what());
+    }
+    return false;
+}
 
 // Determine timestamp adjustment necessary in case of historic data
 void RealTrafficConnection::AdjustTimestamp (double& ts, int nBuffer)

--- a/Src/SettingsUI.cpp
+++ b/Src/SettingsUI.cpp
@@ -264,7 +264,7 @@ void LTSettingsUI::buildInterface()
             }
             
             // --- Airplanes.live ---
-            if (ImGui::TreeNodeCbxLinkHelp("Airplanes.live", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(AIRPLANES_NAME, nCol,
                                            DR_CHANNEL_AIRPLANES_LIVE, "Connect to Airplanes.live for tracking data",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " AIRPLANES_CHECK_NAME,
                                            AIRPLANES_CHECK_URL,
@@ -286,7 +286,7 @@ void LTSettingsUI::buildInterface()
             }
 
             // --- adsb.fi ---
-            if (ImGui::TreeNodeCbxLinkHelp("adsb.fi", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(ADSBFI_NAME, nCol,
                                            DR_CHANNEL_ADSB_FI_ONLINE, "Connect to adsb.fi for tracking data",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " ADSBFI_CHECK_NAME,
                                            ADSBFI_CHECK_URL,
@@ -308,7 +308,7 @@ void LTSettingsUI::buildInterface()
             }
             
             // --- OpenSky ---
-            if (ImGui::TreeNodeCbxLinkHelp("OpenSky Network", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(OPSKY_NAME, nCol,
                                            DR_CHANNEL_OPEN_SKY_ONLINE, "Enable OpenSky tracking data",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " OPSKY_CHECK_NAME,
                                            OPSKY_CHECK_URL,
@@ -319,8 +319,8 @@ void LTSettingsUI::buildInterface()
                 bool bDoSave = false;               // shall the "Save" be executed?
                 OpenSkyConnection* pOpenSkyCh = dynamic_cast<OpenSkyConnection*>(LTFlightDataGetCh(DR_CHANNEL_OPEN_SKY_ONLINE));
                 
-                ImGui::FilteredCfgCheckbox("OpenSky Aircraft DB File", sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERFILE, "Download aircraft database from OpenSky and use it for master data like type, registration...");
-                ImGui::FilteredCfgCheckbox("OpenSky Route Info", sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, "Query OpenSky for route information (departure, destination airports) by call sign.");
+                ImGui::FilteredCfgCheckbox(OPSKY_MDF_NAME, sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERFILE, "Download aircraft database from OpenSky and use it for master data like type, registration...");
+                ImGui::FilteredCfgCheckbox(OPSKY_MD_NAME, sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, "Query OpenSky for route information (departure, destination airports) by call sign.");
 
                 // Hint that registered users have more allowed requests
                 if (!*sFilter && (sOpenSkyClientId.empty() || sOpenSkySecret.empty())) {
@@ -450,7 +450,7 @@ void LTSettingsUI::buildInterface()
             
             // --- ADSBHub ---
             const bool bWasADSBHubEnabled = dataRefs.IsChannelEnabled(DR_CHANNEL_ADSB_HUB);
-            if (ImGui::TreeNodeCbxLinkHelp("ADSBHub", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(ADSBHUB_NAME, nCol,
                                            DR_CHANNEL_ADSB_HUB, "Connect to ADSBHub for tracking data, requires feeder setup",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " ADSBHUB_CHECK_NAME,
                                            ADSBHUB_CHECK_URL,
@@ -478,7 +478,7 @@ void LTSettingsUI::buildInterface()
             }
 
             // --- Open Glider Network ---
-            if (ImGui::TreeNodeCbxLinkHelp("Open Glider Network", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(OPGLIDER_NAME, nCol,
                                            DR_CHANNEL_OPEN_GLIDER_NET, "Enable OGN tracking data",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " "  OPGLIDER_CHECK_NAME,
                                            OPGLIDER_CHECK_URL,
@@ -546,7 +546,7 @@ void LTSettingsUI::buildInterface()
             }
             
             // --- RealTraffic ---
-            if (ImGui::TreeNodeCbxLinkHelp("RealTraffic", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(REALTRAFFIC_NAME, nCol,
                                            DR_CHANNEL_REAL_TRAFFIC_ONLINE,
                                            "Enable RealTraffic tracking data",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " RT_CHECK_NAME,
@@ -705,7 +705,7 @@ void LTSettingsUI::buildInterface()
             }
             
             // --- Navigraph / Flightradar24 ---
-            if (ImGui::TreeNodeCbxLinkHelp("Navigraph/FR24", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(NVGR_NAME, nCol,
                                            DR_CHANNEL_NVGR_FR24, "Connect to Navigraph for Flightradar24 tracking data, requires Navigraph Unlimited",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " NVGR_CHECK_NAME,
                                            NVGR_CHECK_URL,
@@ -823,7 +823,7 @@ void LTSettingsUI::buildInterface()
             }
 
             // --- ADS-B Exchange ---
-            if (ImGui::TreeNodeCbxLinkHelp("ADS-B Exchange", nCol,
+            if (ImGui::TreeNodeCbxLinkHelp(ADSBEX_NAME, nCol,
                                            // we offer the enable checkbox only when an API key is defined
                                            dataRefs.GetADSBExAPIKey().empty() ? dataRefsLT(-1) : DR_CHANNEL_ADSB_EXCHANGE_ONLINE,
                                            dataRefs.GetADSBExAPIKey().empty() ? "ADS-B Exchange requires an API key" : "Enable ADS-B Exchange tracking data",
@@ -1032,10 +1032,10 @@ void LTSettingsUI::buildInterface()
             
             // --- AutoATC ---
             ImGui::Indent();
-            ImGui::FilteredCfgCheckbox("AutoATC", sFilter, DR_CHANNEL_AUTOATC,
+            ImGui::FilteredCfgCheckbox(AATC_NAME, sFilter, DR_CHANNEL_AUTOATC,
                                        "Connect to AutoATC for generated traffic",
                                        false);      // don't move to next cell yet
-            if (ImGui::MatchesFilter("AutoATC", sFilter)) {
+            if (ImGui::MatchesFilter(AATC_NAME, sFilter)) {
                 ImGui::SameLine();
                 ImGui::ButtonURL(ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " AATC_CHECK_NAME, AATC_CHECK_URL, AATC_CHECK_POPUP);
                 ImGui::TableNextCell();

--- a/Src/SettingsUI.cpp
+++ b/Src/SettingsUI.cpp
@@ -319,8 +319,8 @@ void LTSettingsUI::buildInterface()
                 bool bDoSave = false;               // shall the "Save" be executed?
                 OpenSkyConnection* pOpenSkyCh = dynamic_cast<OpenSkyConnection*>(LTFlightDataGetCh(DR_CHANNEL_OPEN_SKY_ONLINE));
                 
-                ImGui::FilteredCfgCheckbox("OpenSky Network Master Data", sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, "Query OpenSky for aicraft master data like type, registration...");
-                ImGui::FilteredCfgCheckbox("OpenSky Network Master File", sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERFILE, "Download aircraft database from OpenSky and use it for master data like type, registration...");
+                ImGui::FilteredCfgCheckbox("OpenSky Aircraft DB File", sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERFILE, "Download aircraft database from OpenSky and use it for master data like type, registration...");
+                ImGui::FilteredCfgCheckbox("OpenSky Route Info", sFilter, DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, "Query OpenSky for route information (departure, destination airports) by call sign.");
 
                 // Hint that registered users have more allowed requests
                 if (!*sFilter && (sOpenSkyClientId.empty() || sOpenSkySecret.empty())) {

--- a/Src/SettingsUI.cpp
+++ b/Src/SettingsUI.cpp
@@ -462,6 +462,7 @@ void LTSettingsUI::buildInterface()
                 // we also make sure that OpenSky Master data is enabled
                 if (!bWasADSBHubEnabled && dataRefs.IsChannelEnabled(DR_CHANNEL_ADSB_HUB)) {
                     dataRefs.SetChannelEnabled(DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, true);
+                    dataRefs.SetChannelEnabled(DR_CHANNEL_OPEN_SKY_AC_MASTERFILE, true);
                 }
                 
                 // ADSBHub's connection status details
@@ -715,12 +716,6 @@ void LTSettingsUI::buildInterface()
                                            sFilter, nOpCl))
             {
                 if (NvgrFR24Connection::IsBuiltIn()) {
-                    // If Navigraph has just been enabled then, as a courtesy,
-                    // we also make sure that OpenSky Master data is enabled
-                    if (!bWasNvgrEnabled && dataRefs.IsChannelEnabled(DR_CHANNEL_NVGR_FR24)) {
-                        dataRefs.SetChannelEnabled(DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, true);
-                    }
-                    
                     // Reset the UI status some time after completion, so we can start over?
                     if (tNvgrReset.time_since_epoch().count() > 0 &&
                         std::chrono::steady_clock::now() >=  tNvgrReset)
@@ -802,7 +797,6 @@ void LTSettingsUI::buildInterface()
                                     case NvgrFR24Connection::NVGR_AUTH_SUCCESS:
                                         ImGui::TextWrapped("LiveTraffic is successfully authorized.");
                                         dataRefs.SetChannelEnabled(DR_CHANNEL_NVGR_FR24, true);
-                                        dataRefs.SetChannelEnabled(DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, true);
                                         break;
                                     default:
                                         ImGui::TextWrapped("Authorization failed, see status below:");

--- a/Src/SettingsUI.cpp
+++ b/Src/SettingsUI.cpp
@@ -459,9 +459,8 @@ void LTSettingsUI::buildInterface()
                                            sFilter, nOpCl))
             {
                 // If ADSBHub has just been enabled then, as a courtesy,
-                // we also make sure that OpenSky Master data is enabled
+                // we also make sure that OpenSky Masterdata File is enabled as it doesn't send a/c type info
                 if (!bWasADSBHubEnabled && dataRefs.IsChannelEnabled(DR_CHANNEL_ADSB_HUB)) {
-                    dataRefs.SetChannelEnabled(DR_CHANNEL_OPEN_SKY_AC_MASTERDATA, true);
                     dataRefs.SetChannelEnabled(DR_CHANNEL_OPEN_SKY_AC_MASTERFILE, true);
                 }
                 
@@ -706,7 +705,6 @@ void LTSettingsUI::buildInterface()
             }
             
             // --- Navigraph / Flightradar24 ---
-            const bool bWasNvgrEnabled = dataRefs.IsChannelEnabled(DR_CHANNEL_NVGR_FR24);
             if (ImGui::TreeNodeCbxLinkHelp("Navigraph/FR24", nCol,
                                            DR_CHANNEL_NVGR_FR24, "Connect to Navigraph for Flightradar24 tracking data, requires Navigraph Unlimited",
                                            ICON_FA_EXTERNAL_LINK_SQUARE_ALT " " NVGR_CHECK_NAME,

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -151,7 +151,16 @@
         <li>Added new <a href="https://twinfan.gitbook.io/livetraffic/setup/installation/navigraph">channel <b>Navigraph/FR24</b></a>.
             You need a <a href="https://navigraph.com/available-products">Navigraph Unlimited subscription</a>.
             Refresh is restricted by Navigraph to 20s period / 150km (80nm) range.</li>
-        <li>Fixed some effects of the flight model changes introduced in v4.5, especially handling of altitude,
+        <li><b>OpenSky Masterdata</b> is needed for OpenSky and some other simpler channels to find the aircraft type
+            of a plane identified by ADS-B id.<br>
+            The OpenSky Masterdata <b>Online</b> channel is no longer available for aircraft info (it was an undocumented API all along).
+            It is still being used for route info, but also that is an undocumented API and may cease soon.<br>
+            The OpenSky Masterdata <b>File</b> interface has been resurrected and is now again enabled by default.
+            LiveTraffic is changed to now allow for the rather slow but steady download of the database file from OpenSky over several minutes.<br>
+            Also this allows for a download of the 2025-08 file only. OpenSky is not currently maintaining this information in an accessible way.
+            Will implement other ways of downloading aircraft info by ADS-B hex id in a future version.
+        </li>
+        <li>Fixed some effects of the <b>flight model changes</b> introduced in v4.5, especially handling of altitude,
             some handling of heading. Not all perfect yet, more fundamental design changes to come.</li>
         </li>
     </ul>

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -154,10 +154,11 @@
         <li><b>OpenSky Masterdata</b> is needed for OpenSky and some other simpler channels to find the aircraft type
             of a plane identified by ADS-B id.<br>
             The OpenSky Masterdata <b>Online</b> channel is no longer available for aircraft info (it was an undocumented API all along).
-            It is still being used for route info, but also that is an undocumented API and may cease soon.<br>
-            The OpenSky Masterdata <b>File</b> interface has been resurrected and is now again enabled by default.
+            It could still be used for route info, but also that is an undocumented API and may cease soon.
+            Hence, by default the channel is now <b>disabled</b>, though it can still be manually activated.<br>
+            The OpenSky Masterdata <b>File</b> interface has been resurrected and is now again <b>enabled</b> by default.
             LiveTraffic is changed to now allow for the rather slow but steady download of the database file from OpenSky over several minutes.<br>
-            Also this allows for a download of the 2025-08 file only. OpenSky is not currently maintaining this information in an accessible way.
+            Also this allows for a download of the 2025-08 file only. OpenSky is not currently maintaining this data in an accessible way.
             Will implement other ways of downloading aircraft info by ADS-B hex id in a future version.
         </li>
         <li>Fixed some effects of the <b>flight model changes</b> introduced in v4.5, especially handling of altitude,

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -151,12 +151,14 @@
         <li>Added new <a href="https://twinfan.gitbook.io/livetraffic/setup/installation/navigraph">channel <b>Navigraph/FR24</b></a>.
             You need a <a href="https://navigraph.com/available-products">Navigraph Unlimited subscription</a>.
             Refresh is restricted by Navigraph to 20s period / 150km (80nm) range.</li>
-        <li><b>OpenSky Masterdata</b> is needed for OpenSky and some other simpler channels to find the aircraft type
-            of a plane identified by ADS-B id.<br>
+        <li><b><a href="https://twinfan.gitbook.io/livetraffic/setup/installation/opensky">OpenSky</a> Masterdata</b> is needed for OpenSky and some other simpler channels like ADSBHub to find the aircraft type
+            of a plane identified by ADS-B id, which is crucial to find a proper CSL model for display.<br>
             The OpenSky Masterdata <b>Online</b> channel is no longer available for aircraft info (it was an undocumented API all along).
             It could still be used for route info, but also that is an undocumented API and may cease soon.
-            Hence, by default the channel is now <b>disabled</b>, though it can still be manually activated.<br>
-            The OpenSky Masterdata <b>File</b> interface has been resurrected and is now again <b>enabled</b> by default.
+            Hence, the channel is now renamed to <b>OpenSky Route Info</b> for clarity
+            and <b>disabled</b> by default, though it can still be manually activated.<br>
+            The OpenSky Masterdata <b>File</b> interface has been resurrected,
+            renamed to <b>OpenSky Aircraft DB File</b> for clarity, and is now again <b>enabled</b> by default.
             LiveTraffic is changed to now allow for the rather slow but steady download of the database file from OpenSky over several minutes.<br>
             Also this allows for a download of the 2025-08 file only. OpenSky is not currently maintaining this data in an accessible way.
             Will implement other ways of downloading aircraft info by ADS-B hex id in a future version.


### PR DESCRIPTION
- [OpenSky](https://twinfan.gitbook.io/livetraffic/setup/installation/opensky) Masterdata is needed for OpenSky and some other simpler channels like ADSBHub to find the aircraft type of a plane identified by ADS-B id, which is crucial to [find a proper CSL model](https://twinfan.gitbook.io/livetraffic/reference/faq#matching) for display.
The OpenSky Masterdata Online channel is no longer available for aircraft info (it was an undocumented API all along). It could still be used for route info, but also that is an undocumented API and may cease soon. Hence, the channel is now renamed to OpenSky Route Info for clarity and disabled by default, though it can still be manually activated.
The OpenSky Masterdata File interface has been resurrected, renamed to OpenSky Aircraft DB File for clarity, and is now again enabled by default. LiveTraffic is changed to now allow for the rather slow but steady download of the database file from OpenSky over several minutes.
Also this allows for a download of the 2025-08 file only. OpenSky is not currently maintaining this data in an accessible way. Will implement other ways of downloading aircraft info by ADS-B hex id in a future version.